### PR TITLE
POC: Simple Store

### DIFF
--- a/apps/mini-rx-angular-demo/src/app/app-routing.module.ts
+++ b/apps/mini-rx-angular-demo/src/app/app-routing.module.ts
@@ -4,6 +4,7 @@ import { TodoShellComponent } from './modules/todo/components/todo-shell/todo-sh
 import { APP_BASE_HREF } from '@angular/common';
 import { CounterShellComponent } from './modules/counter/counter-shell/counter-shell.component';
 import { UserShellComponent } from './modules/user/components/user-shell/user-shell.component';
+import { ArtShellComponent } from './modules/art/components/counter-shell/art-shell.component';
 
 const appRoutes: Routes = [
     {
@@ -14,6 +15,10 @@ const appRoutes: Routes = [
         path: 'products',
         loadChildren: () =>
             import('./modules/products/products.module').then((m) => m.ProductsModule),
+    },
+    {
+        path: 'art',
+        component: ArtShellComponent,
     },
     {
         path: 'counter',

--- a/apps/mini-rx-angular-demo/src/app/app.component.html
+++ b/apps/mini-rx-angular-demo/src/app/app.component.html
@@ -16,8 +16,11 @@
             <li class="nav-item" [routerLinkActive]="'active'">
                 <a class="nav-link" [routerLink]="'/products'">Products</a>
             </li>
-            <li class="nav-item mr-auto" [routerLinkActive]="'active'">
+            <li class="nav-item" [routerLinkActive]="'active'">
                 <a class="nav-link" [routerLink]="'/counter'">Counter</a>
+            </li>
+            <li class="nav-item mr-auto" [routerLinkActive]="'active'">
+                <a class="nav-link" [routerLink]="'/art'">Art</a>
             </li>
             <li class="nav-item" [routerLinkActive]="'active'">
                 <a class="nav-link d-flex align-items-center" [routerLink]="'/user'">

--- a/apps/mini-rx-angular-demo/src/app/app.module.ts
+++ b/apps/mini-rx-angular-demo/src/app/app.module.ts
@@ -14,6 +14,7 @@ import { ProductStateModule } from './modules/products/state/product-state.modul
 import { UserModule } from './modules/user/user.module';
 import { HashLocationStrategy, LocationStrategy } from '@angular/common';
 import { ToastrModule } from 'ngx-toastr';
+import { ArtModule } from './modules/art/art.module';
 
 @NgModule({
     imports: [
@@ -36,6 +37,7 @@ import { ToastrModule } from 'ngx-toastr';
             latency: 250,
         }),
         ProductStateModule,
+        ArtModule,
     ],
     declarations: [AppComponent],
     bootstrap: [AppComponent],

--- a/apps/mini-rx-angular-demo/src/app/modules/art/art.module.ts
+++ b/apps/mini-rx-angular-demo/src/app/modules/art/art.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ArtShellComponent } from './components/counter-shell/art-shell.component';
+import { PixelArtComponent } from './components/counter/pixel-art.component';
+
+@NgModule({
+    declarations: [ArtShellComponent, PixelArtComponent],
+    exports: [ArtShellComponent],
+    imports: [CommonModule],
+})
+export class ArtModule {}

--- a/apps/mini-rx-angular-demo/src/app/modules/art/components/counter-shell/art-shell.component.css
+++ b/apps/mini-rx-angular-demo/src/app/modules/art/components/counter-shell/art-shell.component.css
@@ -1,0 +1,4 @@
+:host {
+    display: block;
+    border: 1px solid red;
+}

--- a/apps/mini-rx-angular-demo/src/app/modules/art/components/counter-shell/art-shell.component.html
+++ b/apps/mini-rx-angular-demo/src/app/modules/art/components/counter-shell/art-shell.component.html
@@ -1,0 +1,3 @@
+<div class="d-flex flex-wrap">
+    <app-pixel-art *ngFor="let item of numSequence(2000)"></app-pixel-art>
+</div>

--- a/apps/mini-rx-angular-demo/src/app/modules/art/components/counter-shell/art-shell.component.ts
+++ b/apps/mini-rx-angular-demo/src/app/modules/art/components/counter-shell/art-shell.component.ts
@@ -1,0 +1,17 @@
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+
+@Component({
+    selector: 'app-counter-shell',
+    templateUrl: './art-shell.component.html',
+    styleUrls: ['./art-shell.component.css'],
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ArtShellComponent implements OnInit {
+    constructor() {}
+
+    ngOnInit(): void {}
+
+    numSequence(n: number): Array<number> {
+        return Array(n);
+    }
+}

--- a/apps/mini-rx-angular-demo/src/app/modules/art/components/counter/pixel-art.component.css
+++ b/apps/mini-rx-angular-demo/src/app/modules/art/components/counter/pixel-art.component.css
@@ -1,0 +1,11 @@
+:host {
+    width: 25px;
+    height: 25px;
+    border: 1px solid white;
+}
+
+.inner {
+    background: #a4c400;
+    width: 100%;
+    height: 100%;
+}

--- a/apps/mini-rx-angular-demo/src/app/modules/art/components/counter/pixel-art.component.html
+++ b/apps/mini-rx-angular-demo/src/app/modules/art/components/counter/pixel-art.component.html
@@ -1,0 +1,4 @@
+
+<div class="inner" [style.opacity]="artState.opacity$ | async">
+
+</div>

--- a/apps/mini-rx-angular-demo/src/app/modules/art/components/counter/pixel-art.component.ts
+++ b/apps/mini-rx-angular-demo/src/app/modules/art/components/counter/pixel-art.component.ts
@@ -1,0 +1,21 @@
+import { ChangeDetectionStrategy, Component, HostListener, OnInit } from '@angular/core';
+import { ArtStateService } from '../../service/art-state.service';
+
+@Component({
+    selector: 'app-pixel-art',
+    templateUrl: './pixel-art.component.html',
+    styleUrls: ['./pixel-art.component.css'],
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    providers: [ArtStateService],
+})
+export class PixelArtComponent implements OnInit {
+    @HostListener('mouseover', ['$event']) onHover(e: MouseEvent) {
+        if (!e.altKey) {
+            this.artState.dec();
+        }
+    }
+
+    constructor(public artState: ArtStateService) {}
+
+    ngOnInit(): void {}
+}

--- a/apps/mini-rx-angular-demo/src/app/modules/art/service/art-state.service.ts
+++ b/apps/mini-rx-angular-demo/src/app/modules/art/service/art-state.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { SimpleStore } from 'mini-rx-store';
+import { Observable } from 'rxjs';
+
+interface CounterState {
+    count: number;
+}
+
+function getInitialState(): CounterState {
+    return {
+        count: Math.floor(Math.random() * 10) + 3,
+    };
+}
+
+@Injectable()
+export class ArtStateService extends SimpleStore<CounterState> {
+    opacity$: Observable<number> = this.select((state) => state.count / 10);
+
+    constructor() {
+        super(getInitialState());
+    }
+
+    dec() {
+        this.setState((state) => ({ count: 0 }));
+    }
+}

--- a/apps/mini-rx-angular-demo/src/app/modules/counter/state/counter-state.service.ts
+++ b/apps/mini-rx-angular-demo/src/app/modules/counter/state/counter-state.service.ts
@@ -2,8 +2,6 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { FeatureStore } from 'mini-rx-store';
 
-let id = 1;
-
 interface CounterState {
     count: number;
 }
@@ -17,7 +15,7 @@ export class CounterStateService extends FeatureStore<CounterState> {
     count$: Observable<number> = this.select((state) => state.count);
 
     constructor() {
-        super('counter-' + id++, initialState); // The counter Feature Stores need a unique feature key
+        super('counter', initialState, { multi: true });
     }
 
     increment() {

--- a/apps/mini-rx-angular-demo/src/app/modules/counter/state/counter-state.service.ts
+++ b/apps/mini-rx-angular-demo/src/app/modules/counter/state/counter-state.service.ts
@@ -15,7 +15,7 @@ export class CounterStateService extends FeatureStore<CounterState> {
     count$: Observable<number> = this.select((state) => state.count);
 
     constructor() {
-        super('counter', initialState, { multi: true });
+        super('counter', initialState, { detached: true });
     }
 
     increment() {

--- a/apps/mini-rx-angular-demo/src/app/modules/counter/state/counter-state.service.ts
+++ b/apps/mini-rx-angular-demo/src/app/modules/counter/state/counter-state.service.ts
@@ -15,7 +15,7 @@ export class CounterStateService extends FeatureStore<CounterState> {
     count$: Observable<number> = this.select((state) => state.count);
 
     constructor() {
-        super('counter', initialState, { detached: true });
+        super('counter', initialState, { multi: true });
     }
 
     increment() {

--- a/libs/mini-rx-store/src/index.ts
+++ b/libs/mini-rx-store/src/index.ts
@@ -7,20 +7,21 @@ export { default as _StoreCore } from './lib/store-core';
 export { FeatureStore } from './lib/feature-store';
 export { createFeatureSelector, createSelector } from './lib/selector';
 export {
-  Action,
-  Reducer,
-  Actions,
-  ReducerDictionary,
-  StoreConfig,
-  FeatureStoreConfig,
-  StoreExtension
+    Action,
+    Reducer,
+    Actions,
+    ReducerDictionary,
+    StoreConfig,
+    FeatureStoreConfig,
+    StoreExtension,
 } from './lib/models';
 export { ofType } from './lib/utils';
 export {
-  ReduxDevtoolsExtension,
-  ReduxDevtoolsOptions,
+    ReduxDevtoolsExtension,
+    ReduxDevtoolsOptions,
 } from './lib/extensions/redux-devtools.extension';
 export { LoggerExtension } from './lib/extensions/logger.extension';
 export { ImmutableStateExtension } from './lib/extensions/immutable-state.extension';
 export { UndoExtension, undo } from './lib/extensions/undo.extension';
-export { tapResponse } from './lib/tap-response'
+export { tapResponse } from './lib/tap-response';
+export { SimpleStore } from './lib/simple-store';

--- a/libs/mini-rx-store/src/lib/feature-store.ts
+++ b/libs/mini-rx-store/src/lib/feature-store.ts
@@ -8,7 +8,6 @@ import { MiniRxActionType, SetStateAction } from './actions';
 
 export class FeatureStore<StateType extends object> {
     state$: Observable<StateType> = StoreCore.select((state) => state[this.featureKey]);
-
     get state(): StateType {
         let value: StateType;
         this.state$
@@ -28,13 +27,13 @@ export class FeatureStore<StateType extends object> {
     private sub = new Subscription();
     private readonly internalFeatureId: number;
 
-    constructor(featureKey: string, initialState: StateType) {
-        this._featureKey = featureKey;
+    constructor(featureKey: string, initialState: StateType, config: { multi?: boolean } = {}) {
         this.internalFeatureId = getInternalFeatureId();
 
-        StoreCore.addFeature<StateType>(
+        this._featureKey = StoreCore.addFeature<StateType>(
             featureKey,
-            createFeatureReducer(this.internalFeatureId, initialState) as Reducer<StateType>
+            createFeatureReducer(this.internalFeatureId, initialState),
+            config
         );
     }
 

--- a/libs/mini-rx-store/src/lib/simple-store.ts
+++ b/libs/mini-rx-store/src/lib/simple-store.ts
@@ -1,0 +1,27 @@
+import { BehaviorSubject, Observable } from 'rxjs';
+import { select } from './utils';
+import { StateOrCallback } from './models';
+import { calcNewState } from './feature-store';
+
+export class SimpleStore<T> {
+    private stateSource: BehaviorSubject<T> = new BehaviorSubject(this.initialState);
+    state$: Observable<T> = this.stateSource.asObservable();
+    get state(): T {
+        return this.stateSource.getValue();
+    }
+
+    constructor(private initialState: T) {}
+
+    select(): Observable<T>;
+    select<R>(mapFn: (state: T) => R): Observable<R>;
+    select(mapFn?: any): Observable<any> {
+        if (!mapFn) {
+            return this.state$;
+        }
+        return this.state$.pipe(select(mapFn));
+    }
+
+    setState(stateOrCallback: StateOrCallback<T>): void {
+        this.stateSource.next(calcNewState(this.state, stateOrCallback));
+    }
+}

--- a/libs/mini-rx-store/src/lib/spec/immutable-state.extension.spec.ts
+++ b/libs/mini-rx-store/src/lib/spec/immutable-state.extension.spec.ts
@@ -124,7 +124,7 @@ describe('Immutable State Extension', () => {
     it('should throw when mutating selected state from a FeatureStore', () => {
         let selectedFeatureState: CounterState;
 
-        fs.select().subscribe(state => selectedFeatureState = state);
+        fs.select().subscribe((state) => (selectedFeatureState = state));
 
         expect(() => (selectedFeatureState.counter = 123)).toThrow();
     });

--- a/libs/mini-rx-store/src/lib/store-core.ts
+++ b/libs/mini-rx-store/src/lib/store-core.ts
@@ -106,13 +106,18 @@ class StoreCore {
         config: {
             metaReducers?: MetaReducer<StateType>[];
             initialState?: StateType;
+            multi?: boolean;
         } = {}
-    ) {
+    ): string {
         reducer = config.metaReducers?.length
             ? combineMetaReducers<StateType>(config.metaReducers)(reducer)
             : reducer;
 
-        checkFeatureExists(featureKey, this.featureReducers);
+        if (!config.multi) {
+            checkFeatureExists(featureKey, this.featureReducers);
+        } else {
+            featureKey = featureKey + '-' + generateId();
+        }
 
         if (typeof config.initialState !== 'undefined') {
             reducer = createReducerWithInitialState(reducer, config.initialState);
@@ -120,6 +125,7 @@ class StoreCore {
 
         this.addReducer(featureKey, reducer);
         this.dispatch(new MiniRxAction('init-feature', featureKey));
+        return featureKey;
     }
 
     removeFeature(featureKey: string) {
@@ -207,6 +213,12 @@ function combineMetaReducers<T>(metaReducers: MetaReducer<T>[]): MetaReducer<T> 
             reducer
         );
     };
+}
+
+// Simple alpha numeric ID: https://stackoverflow.com/a/12502559/453959
+// This isn't a real GUID!
+function generateId() {
+    return Math.random().toString(36).slice(2);
 }
 
 // Created once to initialize singleton

--- a/libs/mini-rx-store/src/lib/store.ts
+++ b/libs/mini-rx-store/src/lib/store.ts
@@ -1,4 +1,4 @@
-import { AppState, StoreConfig } from './models';
+import { AppState, FeatureStoreConfig, Reducer, StoreConfig } from './models';
 import StoreCore from './store-core';
 import { FeatureStore } from './feature-store';
 import { miniRxError } from './utils';
@@ -7,7 +7,14 @@ export class Store {
     private static instance: Store | undefined = undefined;
 
     // Public Store API
-    feature = StoreCore.addFeature.bind(StoreCore);
+    feature<StateType>(
+        featureKey: string,
+        reducer: Reducer<StateType>,
+        config?: FeatureStoreConfig<StateType>
+    ) {
+        StoreCore.addFeature<StateType>(featureKey, reducer, config);
+    }
+
     dispatch = StoreCore.dispatch.bind(StoreCore);
     select = StoreCore.select.bind(StoreCore);
     effect = StoreCore.effect.bind(StoreCore);


### PR DESCRIPTION
A dedicated class for local state management: `SimpleStore`. It exposes this methods and props: `setState`, `select`, `get state`

SimpleStore is almost the same like StateService from my blogpost ["Simple yet powerful state management in Angular with RxJS" ](https://dev.to/angular/simple-yet-powerful-state-management-in-angular-with-rxjs-4f8g)

**Usage**:
```
export class CounterStateService extends SimpleStore<CounterState> {
    constructor() {
        super(initialState);
    }
}

This PR includes also code for the FeatureStore multi config (allow many FeatureStore instances which use the same featureKey).