### PR TITLE
refactor(mini-rx-store): Replace reference …

### DIFF
--- a/libs/mini-rx-store/src/lib/extensions/redux-devtools.extension.ts
+++ b/libs/mini-rx-store/src/lib/extensions/redux-devtools.extension.ts
@@ -3,8 +3,6 @@ import { Action, AppState, StoreExtension } from '../models';
 import StoreCore from '../store-core';
 import { beautifyActionForLogging } from '../utils';
 
-const win = globalThis as any;
-
 const defaultOptions: Partial<ReduxDevtoolsOptions> = {
     name: 'MiniRx - Redux Dev Tools',
 };
@@ -16,7 +14,7 @@ export interface ReduxDevtoolsOptions {
 }
 
 export class ReduxDevtoolsExtension extends StoreExtension {
-    private devtoolsExtension = win.__REDUX_DEVTOOLS_EXTENSION__;
+    private devtoolsExtension = (window as any).__REDUX_DEVTOOLS_EXTENSION__;
     private devtoolsConnection: any;
 
     constructor(private readonly options: Partial<ReduxDevtoolsOptions>) {

--- a/libs/mini-rx-store/src/lib/extensions/redux-devtools.extension.ts
+++ b/libs/mini-rx-store/src/lib/extensions/redux-devtools.extension.ts
@@ -1,7 +1,7 @@
 import { tap, withLatestFrom } from 'rxjs/operators';
 import { Action, AppState, StoreExtension } from '../models';
 import StoreCore from '../store-core';
-import { beautifyActionForLogging } from '../utils';
+import { beautifyActionForLogging, miniRxError } from '../utils';
 
 const defaultOptions: Partial<ReduxDevtoolsOptions> = {
     name: 'MiniRx - Redux Dev Tools',

--- a/libs/mini-rx-store/src/lib/extensions/redux-devtools.extension.ts
+++ b/libs/mini-rx-store/src/lib/extensions/redux-devtools.extension.ts
@@ -19,6 +19,10 @@ export class ReduxDevtoolsExtension extends StoreExtension {
 
     constructor(private readonly options: Partial<ReduxDevtoolsOptions>) {
         super();
+        
+        if (!window) {
+            miniRxError('The Redux DevTools are only supported in Browser environments')
+        }
 
         this.options = {
             ...defaultOptions,

--- a/libs/mini-rx-store/src/lib/extensions/redux-devtools.extension.ts
+++ b/libs/mini-rx-store/src/lib/extensions/redux-devtools.extension.ts
@@ -3,7 +3,7 @@ import { Action, AppState, StoreExtension } from '../models';
 import StoreCore from '../store-core';
 import { beautifyActionForLogging } from '../utils';
 
-const win = window as any;
+const win = globalThis as any;
 
 const defaultOptions: Partial<ReduxDevtoolsOptions> = {
     name: 'MiniRx - Redux Dev Tools',


### PR DESCRIPTION
…-> to `window` with `globalThis` in redux devtools extension. #124 