### PR TITLE
feature(mini-rx-store): lazy feature store initialization

### DIFF
--- a/apps/mini-rx-angular-demo/src/app/app.module.ts
+++ b/apps/mini-rx-angular-demo/src/app/app.module.ts
@@ -9,11 +9,17 @@ import { AppRoutingModule } from './app-routing.module';
 import { TodosModule } from './modules/todos/todos.module';
 import { CounterModule } from './modules/counter/counter.module';
 import { StoreDevtoolsModule, StoreModule } from 'mini-rx-store-ng';
-import { ImmutableStateExtension, LoggerExtension, UndoExtension } from 'mini-rx-store';
+import {
+    ImmutableStateExtension,
+    LoggerExtension,
+    UndoExtension,
+    FeatureStore,
+} from 'mini-rx-store';
 import { ProductsStateModule } from './modules/products/state/products-state.module';
 import { UserModule } from './modules/user/user.module';
 import { HashLocationStrategy, LocationStrategy } from '@angular/common';
 import { ToastrModule } from 'ngx-toastr';
+import { initialState, TodosState } from './modules/todos/state/todos-store.service';
 
 @NgModule({
     imports: [
@@ -43,4 +49,22 @@ import { ToastrModule } from 'ngx-toastr';
     bootstrap: [AppComponent],
     providers: [{ provide: LocationStrategy, useClass: HashLocationStrategy }],
 })
-export class AppModule {}
+export class AppModule {
+    constructor() {
+        const fs = new FeatureStore<TodosState>('test', undefined);
+        const fsState$ = fs.select();
+        fsState$.subscribe((v) => console.log('# test', v));
+
+        // Test lazy initialization
+        setTimeout(() => {
+            fs.setInitialState(initialState);
+        }, 5000);
+
+        setTimeout(() => {
+            // Use setState as usual
+            fs.setState({
+                todos: [{ id: 123, title: 'test', isDone: false }],
+            });
+        }, 6000);
+    }
+}

--- a/apps/mini-rx-angular-demo/src/app/modules/todos/state/todos-store.service.ts
+++ b/apps/mini-rx-angular-demo/src/app/modules/todos/state/todos-store.service.ts
@@ -14,14 +14,14 @@ import {
 import { TodosApiService } from '../../todos-shared/services/todos-api.service';
 
 // STATE INTERFACE
-interface TodosState {
+export interface TodosState {
     todos: Todo[];
     filter: TodoFilter;
     selectedTodo: Todo | undefined;
 }
 
 // INITIAL STATE
-const initialState: TodosState = {
+export const initialState: TodosState = {
     todos: [],
     selectedTodo: undefined,
     filter: {

--- a/libs/mini-rx-store/src/lib/store-core.ts
+++ b/libs/mini-rx-store/src/lib/store-core.ts
@@ -13,7 +13,7 @@ import {
     StoreConfig,
     StoreExtension,
 } from './models';
-import { generateId, hasEffectMetaData, miniRxError, select } from './utils';
+import { hasEffectMetaData, miniRxError, select } from './utils';
 import { defaultEffectsErrorHandler } from './default-effects-error-handler';
 import { combineReducers } from './combine-reducers';
 import { createMiniRxAction, MiniRxActionType } from './actions';
@@ -109,18 +109,13 @@ class StoreCore {
         config: {
             metaReducers?: MetaReducer<StateType>[];
             initialState?: StateType;
-            multi?: boolean;
         } = {}
-    ): string {
+    ): void {
         reducer = config.metaReducers?.length
             ? combineMetaReducers<StateType>(config.metaReducers)(reducer)
             : reducer;
 
-        if (!config.multi) {
-            checkFeatureExists(featureKey, this.featureReducers);
-        } else {
-            featureKey = featureKey + '-' + generateId();
-        }
+        checkFeatureExists(featureKey, this.featureReducers);
 
         if (typeof config.initialState !== 'undefined') {
             reducer = createReducerWithInitialState(reducer, config.initialState);
@@ -128,7 +123,6 @@ class StoreCore {
 
         this.addReducer(featureKey, reducer);
         this.dispatch(createMiniRxAction(MiniRxActionType.INIT_FEATURE, featureKey));
-        return featureKey;
     }
 
     removeFeature(featureKey: string) {

--- a/libs/mini-rx-store/src/lib/utils.ts
+++ b/libs/mini-rx-store/src/lib/utils.ts
@@ -36,12 +36,6 @@ export function hasEffectMetaData(
     return param.hasOwnProperty(EFFECT_METADATA_KEY);
 }
 
-// Simple alpha numeric ID: https://stackoverflow.com/a/12502559/453959
-// This isn't a real GUID!
-export function generateId() {
-    return Math.random().toString(36).slice(2);
-}
-
 export function beautifyActionForLogging(action: Action, state: AppState): Action {
     if (isSetStateAction(action)) {
         return mapSetStateActionToActionWithPayload(action, state);


### PR DESCRIPTION
Sometimes it can be useful to provide initialState later, using `setInitialState`.
Especially when managing local component state:
Imagine the initial state depends on component Inputs / props.

```typescript
const fs = new FeatureStore<TodosState>('test', undefined); // Set undefined explicitly as initial state
const fsState$ = fs.select();
fsState$.subscribe((v) => console.log('# test', v));

// Test lazy initialization
setTimeout(() => {
    fs.setInitialState(initialState); // Provide initial state later
}, 5000);

setTimeout(() => {
    // Use setState as usual
    fs.setState({
        todos: [{ id: 123, title: 'test', isDone: false }],
    });
}, 6000);
```