### PR TITLE
feat(mini-rx-store): component store

### DIFF
--- a/apps/mini-rx-angular-demo/src/app/app-routing.module.ts
+++ b/apps/mini-rx-angular-demo/src/app/app-routing.module.ts
@@ -3,6 +3,7 @@ import { RouterModule, Routes } from '@angular/router';
 import { APP_BASE_HREF } from '@angular/common';
 import { CounterShellComponent } from './modules/counter/counter-shell/counter-shell.component';
 import { UserShellComponent } from './modules/user/components/user-shell/user-shell.component';
+import { PixelArtShellComponent } from './modules/pixel-art/components/pixel-art-shell/pixel-art-shell.component';
 
 const appRoutes: Routes = [
     {
@@ -26,6 +27,10 @@ const appRoutes: Routes = [
     {
         path: 'cart',
         loadChildren: () => import('./modules/cart/cart.module').then((m) => m.CartModule),
+    },
+    {
+        path: 'art',
+        component: PixelArtShellComponent,
     },
     {
         path: 'user',

--- a/apps/mini-rx-angular-demo/src/app/app.component.html
+++ b/apps/mini-rx-angular-demo/src/app/app.component.html
@@ -19,8 +19,11 @@
             <li class="nav-item" [routerLinkActive]="'active'">
                 <a class="nav-link" [routerLink]="'/products'">Products</a>
             </li>
-            <li class="nav-item mr-auto" [routerLinkActive]="'active'">
+            <li class="nav-item" [routerLinkActive]="'active'">
                 <a class="nav-link" [routerLink]="'/counter'">Counter</a>
+            </li>
+            <li class="nav-item mr-auto" [routerLinkActive]="'active'">
+                <a class="nav-link" [routerLink]="'/art'">Art</a>
             </li>
             <li class="nav-item" [routerLinkActive]="'active'">
                 <a class="nav-link d-flex align-items-center" [routerLink]="'/user'">

--- a/apps/mini-rx-angular-demo/src/app/app.module.ts
+++ b/apps/mini-rx-angular-demo/src/app/app.module.ts
@@ -9,11 +9,17 @@ import { AppRoutingModule } from './app-routing.module';
 import { TodosModule } from './modules/todos/todos.module';
 import { CounterModule } from './modules/counter/counter.module';
 import { StoreDevtoolsModule, StoreModule } from 'mini-rx-store-ng';
-import { ImmutableStateExtension, LoggerExtension, UndoExtension } from 'mini-rx-store';
+import {
+    configureComponentStores,
+    ImmutableStateExtension,
+    LoggerExtension,
+    UndoExtension,
+} from 'mini-rx-store';
 import { ProductsStateModule } from './modules/products/state/products-state.module';
 import { UserModule } from './modules/user/user.module';
 import { HashLocationStrategy, LocationStrategy } from '@angular/common';
 import { ToastrModule } from 'ngx-toastr';
+import { PixelArtModule } from './modules/pixel-art/pixel-art.module';
 
 @NgModule({
     imports: [
@@ -38,9 +44,12 @@ import { ToastrModule } from 'ngx-toastr';
             traceLimit: 25,
         }),
         ProductsStateModule,
+        PixelArtModule,
     ],
     declarations: [AppComponent],
     bootstrap: [AppComponent],
     providers: [{ provide: LocationStrategy, useClass: HashLocationStrategy }],
 })
 export class AppModule {}
+
+configureComponentStores({ extensions: [new LoggerExtension()] });

--- a/apps/mini-rx-angular-demo/src/app/modules/pixel-art/components/pixel-art-shell/pixel-art-shell.component.css
+++ b/apps/mini-rx-angular-demo/src/app/modules/pixel-art/components/pixel-art-shell/pixel-art-shell.component.css
@@ -1,0 +1,4 @@
+:host {
+    display: block;
+    border: 1px solid red;
+}

--- a/apps/mini-rx-angular-demo/src/app/modules/pixel-art/components/pixel-art-shell/pixel-art-shell.component.html
+++ b/apps/mini-rx-angular-demo/src/app/modules/pixel-art/components/pixel-art-shell/pixel-art-shell.component.html
@@ -1,0 +1,3 @@
+<div class="d-flex flex-wrap">
+    <app-pixel-art *ngFor="let item of numSequence(2500)"></app-pixel-art>
+</div>

--- a/apps/mini-rx-angular-demo/src/app/modules/pixel-art/components/pixel-art-shell/pixel-art-shell.component.ts
+++ b/apps/mini-rx-angular-demo/src/app/modules/pixel-art/components/pixel-art-shell/pixel-art-shell.component.ts
@@ -1,0 +1,13 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+@Component({
+    selector: 'app-counter-shell',
+    templateUrl: './pixel-art-shell.component.html',
+    styleUrls: ['./pixel-art-shell.component.css'],
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PixelArtShellComponent {
+    numSequence(n: number): Array<number> {
+        return Array(n);
+    }
+}

--- a/apps/mini-rx-angular-demo/src/app/modules/pixel-art/components/pixel-art/pixel-art.component.css
+++ b/apps/mini-rx-angular-demo/src/app/modules/pixel-art/components/pixel-art/pixel-art.component.css
@@ -1,0 +1,12 @@
+:host {
+    width: 20px;
+    height: 20px;
+    border: 1px solid white;
+}
+
+.inner {
+    background: #a4c400;
+    width: 100%;
+    height: 100%;
+    transition: opacity 0.2s;
+}

--- a/apps/mini-rx-angular-demo/src/app/modules/pixel-art/components/pixel-art/pixel-art.component.html
+++ b/apps/mini-rx-angular-demo/src/app/modules/pixel-art/components/pixel-art/pixel-art.component.html
@@ -1,0 +1,1 @@
+<div class="inner" [style.opacity]="artStore.opacity$ | async"></div>

--- a/apps/mini-rx-angular-demo/src/app/modules/pixel-art/components/pixel-art/pixel-art.component.ts
+++ b/apps/mini-rx-angular-demo/src/app/modules/pixel-art/components/pixel-art/pixel-art.component.ts
@@ -1,0 +1,17 @@
+import { ChangeDetectionStrategy, Component, HostListener } from '@angular/core';
+import { ArtStoreService } from '../../state/art-store.service';
+
+@Component({
+    selector: 'app-pixel-art',
+    templateUrl: './pixel-art.component.html',
+    styleUrls: ['./pixel-art.component.css'],
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    providers: [ArtStoreService],
+})
+export class PixelArtComponent {
+    @HostListener('mouseover', ['$event']) onHover(e: MouseEvent) {
+        this.artStore.reset();
+    }
+
+    constructor(public artStore: ArtStoreService) {}
+}

--- a/apps/mini-rx-angular-demo/src/app/modules/pixel-art/pixel-art.module.ts
+++ b/apps/mini-rx-angular-demo/src/app/modules/pixel-art/pixel-art.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { PixelArtShellComponent } from './components/pixel-art-shell/pixel-art-shell.component';
+import { PixelArtComponent } from './components/pixel-art/pixel-art.component';
+
+@NgModule({
+    declarations: [PixelArtShellComponent, PixelArtComponent],
+    exports: [PixelArtShellComponent],
+    imports: [CommonModule],
+})
+export class PixelArtModule {}

--- a/apps/mini-rx-angular-demo/src/app/modules/pixel-art/state/art-store.service.ts
+++ b/apps/mini-rx-angular-demo/src/app/modules/pixel-art/state/art-store.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@angular/core';
+import { ComponentStore } from 'mini-rx-store';
+import { Observable, timer } from 'rxjs';
+import { map, take } from 'rxjs/operators';
+
+interface ArtState {
+    opacity: number;
+}
+
+const initialState: ArtState = {
+    opacity: 1,
+};
+
+@Injectable()
+export class ArtStoreService extends ComponentStore<ArtState> {
+    opacity$: Observable<number> = this.select((state) => state.opacity);
+
+    constructor() {
+        super(initialState);
+
+        const delayedOpacity$: Observable<ArtState> = timer(Math.random() * 5000).pipe(
+            take(1),
+            map(() => ({ opacity: Math.random() }))
+        );
+
+        // You could use JS setTimeout, but that approach would require some cleanup code to cancel the timer when the component destroys
+        // setState with Observable manages cleanup (of subscriptions) internally
+        this.setState(delayedOpacity$);
+    }
+
+    reset() {
+        this.setState(initialState);
+    }
+}

--- a/apps/mini-rx-angular-demo/src/app/modules/products/state/products.actions.ts
+++ b/apps/mini-rx-angular-demo/src/app/modules/products/state/products.actions.ts
@@ -1,34 +1,34 @@
 import { Product } from '../models/product';
 import { action, payload } from 'ts-action';
 
-export const toggleProductCode = action('[Product] Toggle Product Code', payload<boolean>());
-export const selectProduct = action('[Product] Select Product', payload<Product>());
-export const clearCurrentProduct = action('[Product] Clear Current Product');
-export const initializeNewProduct = action('[Product] Initialize New Product');
+export const toggleProductCode = action('[Products] Toggle Product Code', payload<boolean>());
+export const selectProduct = action('[Products] Select Product', payload<Product>());
+export const clearCurrentProduct = action('[Products] Clear Current Product');
+export const initializeNewProduct = action('[Products] Initialize New Product');
 
-export const load = action('[Product] Load');
-export const loadSuccess = action('[Product] Load Success', payload<Product[]>());
-export const loadFail = action('[Product] Load Fail', payload<string>());
+export const load = action('[Products] Load');
+export const loadSuccess = action('[Products] Load Success', payload<Product[]>());
+export const loadFail = action('[Products] Load Fail', payload<string>());
 
-export const updateProduct = action('[Product] Update Product', payload<Product>());
+export const updateProduct = action('[Products] Update Product', payload<Product>());
 export const updateProductOptimistic = action(
-    '[Product] Update Product Optimistic',
+    '[Products] Update Product Optimistic',
     payload<Product>()
 );
-export const updateProductSuccess = action('[Product] Update Product Success', payload<Product>());
-export const updateProductFail = action('[Product] Update Product Fail', payload<string>());
+export const updateProductSuccess = action('[Products] Update Product Success', payload<Product>());
+export const updateProductFail = action('[Products] Update Product Fail', payload<string>());
 
-export const createProduct = action('[Product] Create Product', payload<Product>());
-export const createProductSuccess = action('[Product] Create Product Success', payload<Product>());
-export const createProductFail = action('[Product] Create Product Fail', payload<string>());
+export const createProduct = action('[Products] Create Product', payload<Product>());
+export const createProductSuccess = action('[Products] Create Product Success', payload<Product>());
+export const createProductFail = action('[Products] Create Product Fail', payload<string>());
 
-export const deleteProduct = action('[Product] Delete Product', payload<number>());
-export const deleteProductSuccess = action('[Product] Delete Product Success', payload<number>());
-export const deleteProductFail = action('[Product] Delete Product Fail', payload<string>());
+export const deleteProduct = action('[Products] Delete Product', payload<number>());
+export const deleteProductSuccess = action('[Products] Delete Product Success', payload<number>());
+export const deleteProductFail = action('[Products] Delete Product Fail', payload<string>());
 
-export const updateSearch = action('[Product] Update Search', payload<string>());
-export const addProductToCart = action('[Product] Add Product To Cart', payload<number>());
+export const updateSearch = action('[Products] Update Search', payload<string>());
+export const addProductToCart = action('[Products] Add Product To Cart', payload<number>());
 export const removeProductFromCart = action(
-    '[Product] Remove Product From Cart',
+    '[Products] Remove Product From Cart',
     payload<number>()
 );

--- a/libs/mini-rx-store-ng/src/lib/spec/ng-modules.spec.ts
+++ b/libs/mini-rx-store-ng/src/lib/spec/ng-modules.spec.ts
@@ -153,6 +153,8 @@ describe(`Ng Modules`, () => {
     const extensionSpy = jest.fn();
 
     class SomeExtension extends StoreExtension {
+        id = 1; // id does not matter, but it has to be implemented
+
         init(): void {
             extensionSpy();
         }

--- a/libs/mini-rx-store-ng/tsconfig.lib.json
+++ b/libs/mini-rx-store-ng/tsconfig.lib.json
@@ -1,12 +1,13 @@
 {
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "outDir": "../../dist/out-tsc",
-    "declaration": true,
-    "declarationMap": true,
-    "inlineSources": true,
-    "types": []
-  },
-  "exclude": ["src/test-setup.ts", "**/*.spec.ts", "**/*.test.ts"],
-  "include": ["**/*.ts"]
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../dist/out-tsc",
+        "declaration": true,
+        "declarationMap": true,
+        "inlineSources": true,
+        "types": [],
+        "stripInternal": true
+    },
+    "exclude": ["src/test-setup.ts", "**/*.spec.ts", "**/*.test.ts"],
+    "include": ["**/*.ts"]
 }

--- a/libs/mini-rx-store/src/index.ts
+++ b/libs/mini-rx-store/src/index.ts
@@ -2,10 +2,20 @@
  * Public API Surface of mini-rx-store
  */
 
-export { actions$, Store, configureStore } from './lib/store';
-export { default as _StoreCore } from './lib/store-core';
+export { Store, configureStore } from './lib/store';
+export { actions$ } from './lib/store-core';
 export { FeatureStore, createFeatureStore } from './lib/feature-store';
-export { createFeatureSelector, createSelector } from './lib/selector';
+export {
+    ComponentStore,
+    createComponentStore,
+    configureComponentStores,
+} from './lib/component-store';
+export {
+    createFeatureSelector,
+    createSelector,
+    createFeatureStateSelector,
+    createComponentStateSelector,
+} from './lib/selector';
 export {
     Action,
     Reducer,
@@ -22,7 +32,12 @@ export {
 } from './lib/extensions/redux-devtools.extension';
 export { LoggerExtension } from './lib/extensions/logger.extension';
 export { ImmutableStateExtension } from './lib/extensions/immutable-state.extension';
-export { UndoExtension, undo } from './lib/extensions/undo.extension';
+export { UndoExtension } from './lib/extensions/undo.extension';
 export { tapResponse } from './lib/tap-response';
 export { mapResponse } from './lib/map-response';
 export { createEffect } from './lib/create-effect';
+export { undo } from './lib/actions';
+
+// Attention: The API of StoreCore is meant of internal use, e.g. for the Angular `NgReduxDevtoolsService`
+// The StoreCore API can change anytime soon!
+export * as _StoreCore from './lib/store-core';

--- a/libs/mini-rx-store/src/lib/actions-on-queue.ts
+++ b/libs/mini-rx-store/src/lib/actions-on-queue.ts
@@ -1,0 +1,14 @@
+import { queueScheduler, Subject } from 'rxjs';
+import { observeOn } from 'rxjs/operators';
+import { Action, Actions } from './models';
+
+export class ActionsOnQueue {
+    private actionsSource = new Subject<Action>();
+    actions$: Actions = this.actionsSource.asObservable().pipe(
+        observeOn(queueScheduler) // Prevent stack overflow: https://blog.cloudboost.io/so-how-does-rx-js-queuescheduler-actually-work-188c1b46526e
+    );
+
+    dispatch(action: Action) {
+        this.actionsSource.next(action);
+    }
+}

--- a/libs/mini-rx-store/src/lib/base-store.ts
+++ b/libs/mini-rx-store/src/lib/base-store.ts
@@ -1,0 +1,113 @@
+import { isObservable, Observable, Subject, Subscription } from 'rxjs';
+import { miniRxError } from './utils';
+import { Action, SetStateParam, SetStateReturn, StateOrCallback } from './models';
+import { defaultEffectsErrorHandler } from './default-effects-error-handler';
+import { State } from './state';
+
+// BaseStore is extended by ComponentStore/FeatureStore
+export abstract class BaseStore<StateType extends object> {
+    /**
+     * @internal Used by ComponentStore/FeatureStore
+     */
+    protected _sub: Subscription = new Subscription();
+    /**
+     * @internal Used by ComponentStore/FeatureStore
+     */
+    protected _state = new State<StateType>();
+    /** @deprecated Use the `select` method without arguments */
+    state$: Observable<StateType> = this._state.select();
+    get state(): StateType {
+        this.assertStateIsInitialized();
+        return this._state.get()!;
+    }
+    private isStateInitialized = false;
+    private notInitializedErrorMessage =
+        `${this.constructor.name} has no initialState yet. ` +
+        `Please provide an initialState before updating/getting state.`;
+    private initializedErrorMessage = `${this.constructor.name} has initialState already.`;
+
+    // Called by ComponentStore/FeatureStore
+    setInitialState(initialState: StateType): void {
+        this.assertStateIsNotInitialized();
+        this.isStateInitialized = true;
+        // Update state happens in ComponentStore/FeatureStore
+    }
+
+    setState<P extends SetStateParam<StateType>>(
+        stateOrCallback: P,
+        name?: string
+    ): SetStateReturn<StateType, P> {
+        const dispatchFn = (stateOrCallback: StateOrCallback<StateType>, name?: string): Action => {
+            this.assertStateIsInitialized();
+            return this._dispatchSetStateAction(stateOrCallback, name);
+        };
+
+        return (
+            isObservable(stateOrCallback)
+                ? this._sub.add(stateOrCallback.subscribe((v) => dispatchFn(v, name)))
+                : dispatchFn(stateOrCallback as StateOrCallback<StateType>, name)
+        ) as SetStateReturn<StateType, P>;
+    }
+
+    /** @internal
+     * Implemented by ComponentStore/FeatureStore
+     */
+    abstract _dispatchSetStateAction(
+        stateOrCallback: StateOrCallback<StateType>,
+        name?: string
+    ): Action;
+
+    // Implemented by ComponentStore/FeatureStore
+    abstract undo(action: Action): void;
+
+    effect<
+        // Credits for the typings go to NgRx (Component Store): https://github.com/ngrx/platform/blob/13.1.0/modules/component-store/src/component-store.ts#L279-L291
+        ProvidedType = void,
+        // The actual origin$ type, which could be unknown, when not specified
+        OriginType extends Observable<ProvidedType> | unknown = Observable<ProvidedType>,
+        // Unwrapped actual type of the origin$ Observable, after default was applied
+        ObservableType = OriginType extends Observable<infer A> ? A : never,
+        // Return either an empty callback or a function requiring specific types as inputs
+        ReturnType = ProvidedType | ObservableType extends void
+            ? () => void
+            : (observableOrValue: ObservableType | Observable<ObservableType>) => void
+    >(effectFn: (origin$: OriginType) => Observable<unknown>): ReturnType {
+        const subject = new Subject<ObservableType>();
+        const effect$ = effectFn(subject as OriginType);
+        const effectWithDefaultErrorHandler = defaultEffectsErrorHandler(effect$);
+
+        this._sub.add(effectWithDefaultErrorHandler.subscribe());
+
+        return ((observableOrValue?: ObservableType | Observable<ObservableType>) => {
+            isObservable(observableOrValue)
+                ? this._sub.add(observableOrValue.subscribe((v) => subject.next(v)))
+                : subject.next(observableOrValue as ObservableType);
+        }) as unknown as ReturnType;
+    }
+
+    private assertStateIsInitialized(): void {
+        if (!this.isStateInitialized) {
+            miniRxError(this.notInitializedErrorMessage);
+        }
+    }
+
+    private assertStateIsNotInitialized(): void {
+        if (this.isStateInitialized) {
+            miniRxError(this.initializedErrorMessage);
+        }
+    }
+
+    select = this._state.select.bind(this._state);
+
+    destroy() {
+        this._sub.unsubscribe();
+    }
+
+    /**
+     * @internal
+     * Can be called by Angular if ComponentStore/FeatureStore is provided in a component
+     */
+    ngOnDestroy() {
+        this.destroy();
+    }
+}

--- a/libs/mini-rx-store/src/lib/component-store.ts
+++ b/libs/mini-rx-store/src/lib/component-store.ts
@@ -1,0 +1,191 @@
+import { BaseStore } from './base-store';
+import {
+    Action,
+    ComponentStoreConfig,
+    ComponentStoreExtension,
+    ComponentStoreLike,
+    ExtensionId,
+    MetaReducer,
+    Reducer,
+    StateOrCallback,
+} from './models';
+import { calcNewState, combineMetaReducers, miniRxError, sortExtensions } from './utils';
+import {
+    ComponentStoreSetStateAction,
+    createMiniRxAction,
+    createMiniRxActionType,
+    isComponentStoreSetStateAction,
+    MiniRxActionType,
+    SetStateActionType,
+    undo,
+} from './actions';
+import { ActionsOnQueue } from './actions-on-queue';
+
+let componentStoreConfig: ComponentStoreConfig | undefined = undefined;
+
+/** @internal
+ * This function exists for testing purposes only
+ */
+export function _resetConfig() {
+    componentStoreConfig = undefined;
+}
+
+export function configureComponentStores(config: { extensions: ComponentStoreExtension[] }) {
+    if (!componentStoreConfig) {
+        componentStoreConfig = config;
+        return;
+    }
+    miniRxError('`configureComponentStores` was called multiple times.');
+}
+
+const csFeatureKey = 'component-store';
+
+export class ComponentStore<StateType extends object>
+    extends BaseStore<StateType>
+    implements ComponentStoreLike<StateType>
+{
+    private actionsOnQueue = new ActionsOnQueue();
+    private readonly combinedMetaReducer: MetaReducer<StateType>;
+    private reducer: Reducer<StateType> | undefined;
+    private hasUndoExtension = false;
+    private extensions: ComponentStoreExtension[] = []; // This is a class property just for testing purposes
+
+    constructor(initialState?: StateType, config?: ComponentStoreConfig) {
+        super();
+
+        const metaReducers: MetaReducer<StateType>[] = [];
+
+        if (config?.extensions) {
+            if (config.extensions && componentStoreConfig?.extensions) {
+                this.extensions = mergeExtensions(
+                    componentStoreConfig.extensions,
+                    config.extensions
+                );
+            } else {
+                this.extensions = config.extensions;
+            }
+        } else if (componentStoreConfig?.extensions) {
+            this.extensions = componentStoreConfig.extensions;
+        }
+
+        sortExtensions(this.extensions).forEach((ext) => {
+            if (!ext.hasCsSupport) {
+                miniRxError(
+                    `Extension "${ext.constructor.name}" is not supported by Component Store.`
+                );
+            }
+
+            metaReducers.push(ext.init()!); // Non-null assertion: Here we know for sure: init will return a MetaReducer
+
+            if (ext.id === ExtensionId.UNDO) {
+                this.hasUndoExtension = true;
+            }
+        });
+
+        this.combinedMetaReducer = combineMetaReducers(metaReducers);
+
+        this._sub.add(
+            this.actionsOnQueue.actions$.subscribe((action) => {
+                const newState: StateType = this.reducer!(
+                    // We are sure, there is a reducer!
+                    this._state.get()!, // Initially undefined, but the reducer can handle undefined (by falling back to initial state)
+                    action
+                );
+                this._state.set(newState);
+            })
+        );
+
+        if (initialState) {
+            this.setInitialState(initialState);
+        }
+    }
+
+    override setInitialState(initialState: StateType): void {
+        super.setInitialState(initialState);
+
+        this.reducer = this.combinedMetaReducer(createComponentStoreReducer(initialState));
+        this.dispatch(createMiniRxAction(MiniRxActionType.INIT, csFeatureKey));
+    }
+
+    /** @internal
+     * Implementation of abstract method from BaseStore
+     */
+    _dispatchSetStateAction(
+        stateOrCallback: StateOrCallback<StateType>,
+        name: string | undefined
+    ): Action {
+        const action: Action = createSetStateAction(stateOrCallback, name);
+        this.dispatch(action);
+        return action;
+    }
+
+    private dispatch(action: Action) {
+        this.actionsOnQueue.dispatch(action);
+    }
+
+    // Implementation of abstract method from BaseStore
+    undo(action: Action) {
+        this.hasUndoExtension
+            ? this.dispatch(undo(action))
+            : miniRxError(`${this.constructor.name} has no UndoExtension yet.`);
+    }
+}
+
+function createSetStateAction<T>(
+    stateOrCallback: StateOrCallback<T>,
+    name?: string
+): ComponentStoreSetStateAction<T> {
+    const miniRxActionType = MiniRxActionType.SET_STATE;
+    return {
+        setStateActionType: SetStateActionType.COMPONENT_STORE,
+        type: createMiniRxActionType(miniRxActionType, csFeatureKey) + (name ? '/' + name : ''),
+        stateOrCallback,
+    };
+}
+
+function createComponentStoreReducer<StateType>(initialState: StateType): Reducer<StateType> {
+    return (state: StateType = initialState, action: Action) => {
+        if (isComponentStoreSetStateAction<StateType>(action)) {
+            return calcNewState(state, action.stateOrCallback);
+        }
+        return state;
+    };
+}
+
+function mergeExtensions(
+    global: ComponentStoreExtension[],
+    local: ComponentStoreExtension[]
+): ComponentStoreExtension[] {
+    // Local extensions overwrite the global extensions
+    // If extension is global and local => use local
+    // If extension is only global => use global
+    // If extension is only local => use local
+
+    const extensions: ComponentStoreExtension[] = [];
+    let globalCopy = [...global];
+    let localCopy = [...local];
+
+    global.forEach((globalExt) => {
+        local.forEach((localExt) => {
+            if (localExt.id === globalExt.id) {
+                // Found extension which is global and local
+                extensions.push(localExt); // Use local!
+                localCopy = localCopy.filter((item) => item.id !== localExt.id); // Remove found extension from local
+                globalCopy = globalCopy.filter((item) => item.id !== globalExt.id); // Remove found extension from global
+            }
+        });
+    });
+
+    return [
+        ...extensions, // Extensions which are global and local, but use local
+        ...localCopy, // Local only
+        ...globalCopy, // Global only
+    ];
+}
+
+export function createComponentStore<T extends object>(
+    initialState?: T | undefined,
+    config?: ComponentStoreConfig
+): ComponentStore<T> {
+    return new ComponentStore<T>(initialState, config);
+}

--- a/libs/mini-rx-store/src/lib/create-effect.ts
+++ b/libs/mini-rx-store/src/lib/create-effect.ts
@@ -24,7 +24,7 @@
 // SOFTWARE.
 
 import { Observable } from 'rxjs';
-import { EFFECT_METADATA_KEY, HasEffectMetadata, EffectConfig, Action } from './models';
+import { Action, EFFECT_METADATA_KEY, EffectConfig, HasEffectMetadata } from './models';
 
 const DEFAULT_EFFECT_CONFIG: Readonly<Required<EffectConfig>> = {
     dispatch: true,

--- a/libs/mini-rx-store/src/lib/extensions/immutable-state.extension.ts
+++ b/libs/mini-rx-store/src/lib/extensions/immutable-state.extension.ts
@@ -23,19 +23,30 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { Action, Reducer, StoreExtension } from '../models';
-import StoreCore from '../store-core';
+import {
+    Action,
+    ExtensionId,
+    HasComponentStoreSupport,
+    MetaReducer,
+    Reducer,
+    StoreExtension,
+} from '../models';
 import { deepFreeze } from '../deep-freeze';
 
-export class ImmutableStateExtension extends StoreExtension {
-    init(): void {
-        StoreCore.addMetaReducers(storeFreeze);
+export class ImmutableStateExtension extends StoreExtension implements HasComponentStoreSupport {
+    id = ExtensionId.IMMUTABLE_STATE;
+    hasCsSupport = true as const;
+
+    init(): MetaReducer<any> {
+        return storeFreeze;
     }
 }
 
-export function storeFreeze(reducer: Reducer<any>): Reducer<any> {
-    return (state = {}, action: Action) => {
-        deepFreeze(state);
+function storeFreeze(reducer: Reducer<any>): Reducer<any> {
+    return (state, action: Action) => {
+        if (state) {
+            deepFreeze(state);
+        }
         const nextState = reducer(state, action);
         deepFreeze(nextState);
         return nextState;

--- a/libs/mini-rx-store/src/lib/extensions/logger.extension.ts
+++ b/libs/mini-rx-store/src/lib/extensions/logger.extension.ts
@@ -1,16 +1,25 @@
-import { Action, Reducer, StoreExtension } from '../models';
-import StoreCore from '../store-core';
+import {
+    Action,
+    ExtensionId,
+    HasComponentStoreSupport,
+    MetaReducer,
+    Reducer,
+    StoreExtension,
+} from '../models';
 import { beautifyActionForLogging } from '../utils';
 
-export class LoggerExtension extends StoreExtension {
-    init(): void {
-        StoreCore.addMetaReducers(loggerMetaReducer);
+export class LoggerExtension extends StoreExtension implements HasComponentStoreSupport {
+    id = ExtensionId.LOGGER;
+    hasCsSupport = true as const;
+
+    init(): MetaReducer<any> {
+        return loggerMetaReducer;
     }
 }
 
 function loggerMetaReducer(reducer: Reducer<any>): Reducer<any> {
     return (state, action) => {
-        let actionToLog: Action = beautifyActionForLogging(action, state);
+        const actionToLog: Action = beautifyActionForLogging(action, state);
 
         const nextState = reducer(state, action);
 

--- a/libs/mini-rx-store/src/lib/extensions/redux-devtools.extension.ts
+++ b/libs/mini-rx-store/src/lib/extensions/redux-devtools.extension.ts
@@ -1,6 +1,6 @@
 import { tap, withLatestFrom } from 'rxjs/operators';
-import { Action, AppState, StoreExtension } from '../models';
-import StoreCore from '../store-core';
+import { Action, AppState, ExtensionId, StoreExtension } from '../models';
+import { actions$, appState } from '../store-core';
 import { beautifyActionForLogging, miniRxError } from '../utils';
 
 const defaultOptions: Partial<ReduxDevtoolsOptions> = {
@@ -17,6 +17,8 @@ export interface ReduxDevtoolsOptions {
 }
 
 export class ReduxDevtoolsExtension extends StoreExtension {
+    id = ExtensionId.REDUX_DEVTOOLS;
+
     private devtoolsExtension: any;
     private devtoolsConnection: any;
 
@@ -35,13 +37,13 @@ export class ReduxDevtoolsExtension extends StoreExtension {
         };
     }
 
-    init() {
+    init(): void {
         if (this.devtoolsExtension) {
             this.devtoolsConnection = this.devtoolsExtension.connect(this.options);
 
-            StoreCore.actions$
+            actions$
                 .pipe(
-                    withLatestFrom(StoreCore.state$),
+                    withLatestFrom(appState.select()),
                     tap(([action, state]) => {
                         const actionForDevTools: Action = beautifyActionForLogging(action, state);
                         this.devtoolsConnection.send(actionForDevTools, state);
@@ -64,7 +66,7 @@ export class ReduxDevtoolsExtension extends StoreExtension {
     }
 
     protected updateState(state: AppState) {
-        StoreCore.updateState(state);
+        appState.set(state);
     }
 }
 

--- a/libs/mini-rx-store/src/lib/models.ts
+++ b/libs/mini-rx-store/src/lib/models.ts
@@ -10,10 +10,30 @@ export const enum ExtensionSortOrder {
 
 export type AppState = Record<string, any>;
 
+export const enum ExtensionId {
+    IMMUTABLE_STATE,
+    UNDO,
+    LOGGER,
+    REDUX_DEVTOOLS,
+}
+
 export abstract class StoreExtension {
+    abstract id: ExtensionId;
     sortOrder: ExtensionSortOrder = ExtensionSortOrder.DEFAULT;
 
-    abstract init(): void;
+    abstract init(): MetaReducer<any> | void;
+}
+
+export interface HasComponentStoreSupport {
+    hasCsSupport: true;
+
+    init(): MetaReducer<any>;
+}
+
+export type ComponentStoreExtension = StoreExtension & HasComponentStoreSupport;
+
+export interface ComponentStoreConfig {
+    extensions: ComponentStoreExtension[];
 }
 
 export interface Action {
@@ -73,4 +93,19 @@ export interface EffectConfig {
 
 export interface HasEffectMetadata {
     [EFFECT_METADATA_KEY]: EffectConfig;
+}
+
+export type SetStateParam<T> = StateOrCallback<T> | Observable<Partial<T>>;
+export type SetStateReturn<T, P extends SetStateParam<T>> = P extends Observable<Partial<T>>
+    ? void
+    : Action;
+
+export interface ComponentStoreLike<StateType> {
+    setInitialState(initialState: StateType): void;
+    setState(stateOrCallback: SetStateParam<StateType>, name?: string): void;
+    get state(): StateType;
+    select(mapFn?: any): Observable<any>;
+    effect(effectFn: (origin$: Observable<any>) => Observable<any>): () => void;
+    undo(action: Action): void;
+    destroy(): void;
 }

--- a/libs/mini-rx-store/src/lib/selector.ts
+++ b/libs/mini-rx-store/src/lib/selector.ts
@@ -107,16 +107,22 @@ export function createSelector(...args: any[]): Selector<any, any> {
     });
 }
 
+/** @deprecated Use `createFeatureStateSelector` which is more in line with `createComponentStateSelector` */
 export function createFeatureSelector<T>(featureKey?: string): Selector<object, T>;
+/** @deprecated Use `createFeatureStateSelector` which is more in line with `createComponentStateSelector` */
 export function createFeatureSelector<T, V>(featureKey: keyof T): Selector<T, V>;
+/** @deprecated Use `createFeatureStateSelector` which is more in line with `createComponentStateSelector` */
 export function createFeatureSelector(featureKey?: any): Selector<any, any> {
-    return createSelector(
-        (state: any) => {
-            if (featureKey) {
-                return state[featureKey];
-            }
-            return state;
-        },
-        (featureState) => featureState
-    );
+    if (featureKey) {
+        return createSelector(
+            (state: any) => state[featureKey],
+            (featureState) => featureState
+        );
+    }
+    return (state) => state; // Do not memoize: when used with FeatureStore there is a new state object created for every `setState`
+}
+
+export const createFeatureStateSelector = createFeatureSelector;
+export function createComponentStateSelector<T>(): Selector<T, T> {
+    return (state: T) => state;
 }

--- a/libs/mini-rx-store/src/lib/spec/_spec-helpers.ts
+++ b/libs/mini-rx-store/src/lib/spec/_spec-helpers.ts
@@ -1,7 +1,8 @@
 import { Action, ActionWithPayload, Reducer } from '../models';
 import { configureStore, Store } from '../store';
-import { default as StoreCore } from '../store-core';
 import { v4 as uuid } from 'uuid';
+import { combineReducers } from '../combine-reducers';
+import { reducerState } from '../store-core';
 
 export interface UserState {
     firstName: string;
@@ -22,10 +23,10 @@ export const userState: UserState = {
 export const store: Store = configureStore({});
 
 export function resetStoreConfig() {
-    StoreCore['extensions'] = [];
-    StoreCore['reducerStateSource'].next({
+    reducerState.set({
         metaReducers: [],
         featureReducers: {},
+        combineReducersFn: combineReducers,
     });
 }
 

--- a/libs/mini-rx-store/src/lib/spec/combine-reducers.spec.ts
+++ b/libs/mini-rx-store/src/lib/spec/combine-reducers.spec.ts
@@ -55,16 +55,16 @@ describe('combine Reducers', () => {
     it('should combine reducers', () => {
         combinedReducer = combineReducers({
             feature1: reducer,
-            feature2: reducer2
+            feature2: reducer2,
         });
 
         const newState = combinedReducer({}, action1);
-        expect(newState).toEqual({ feature1: {showProductCode: true }});
+        expect(newState).toEqual({ feature1: { showProductCode: true } });
 
         const newState2 = combinedReducer(newState, action2);
         expect(newState2).toEqual({
-            feature1: {showProductCode: true},
-            feature2: {showProductCode2: false}
+            feature1: { showProductCode: true },
+            feature2: { showProductCode2: false },
         });
 
         const combinedReducer2 = combineReducers({
@@ -76,22 +76,25 @@ describe('combine Reducers', () => {
         const newState3 = combinedReducer2(newState2, action3);
 
         expect(newState3).toEqual({
-            feature1: {showProductCode: true},
-            feature2: {showProductCode2: false},
-            feature3: {showProductCode3: undefined}
+            feature1: { showProductCode: true },
+            feature2: { showProductCode2: false },
+            feature3: { showProductCode3: undefined },
         });
     });
 
     it('should remove keys from state which are not present in the reducer map', () => {
-        const newState = combinedReducer({
-            feature1: {showProductCode: true },
-            feature2: {showProductCode2: false },
-            feature3: {showProductCode2: false }
-        }, action2);
+        const newState = combinedReducer(
+            {
+                feature1: { showProductCode: true },
+                feature2: { showProductCode2: false },
+                feature3: { showProductCode2: false },
+            },
+            action2
+        );
 
         expect(newState).toEqual({
-            feature1: {showProductCode: true },
-            feature2: {showProductCode2: false }
+            feature1: { showProductCode: true },
+            feature2: { showProductCode2: false },
         });
     });
 });

--- a/libs/mini-rx-store/src/lib/spec/component-store.spec.ts
+++ b/libs/mini-rx-store/src/lib/spec/component-store.spec.ts
@@ -1,0 +1,316 @@
+import { _resetConfig, configureComponentStores, createComponentStore } from '../component-store';
+import { counterInitialState, CounterState, userState } from './_spec-helpers';
+import { Observable, of, pipe, Subject } from 'rxjs';
+import { map, tap } from 'rxjs/operators';
+import { createComponentStateSelector, createSelector } from '../selector';
+import { LoggerExtension } from '../extensions/logger.extension';
+import { ImmutableStateExtension } from '../extensions/immutable-state.extension';
+import { UndoExtension } from '../extensions/undo.extension';
+import { ComponentStoreExtension, ExtensionId, StoreExtension } from '../models';
+
+describe('ComponentStore', () => {
+    it('should initialize the store', () => {
+        const cs = createComponentStore(counterInitialState);
+
+        const spy = jest.fn();
+        cs.select().subscribe(spy);
+        expect(spy).toHaveBeenCalledWith(counterInitialState);
+        expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should update state', () => {
+        const cs = createComponentStore(counterInitialState);
+
+        const spy = jest.fn();
+        cs.select().subscribe(spy);
+        expect(spy).toHaveBeenCalledWith(counterInitialState);
+        expect(spy).toHaveBeenCalledTimes(1);
+
+        spy.mockReset();
+
+        cs.setState((state) => ({ counter: state.counter + 1 }));
+        expect(spy).toHaveBeenCalledWith({ counter: 2 });
+        expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should update state partially', () => {
+        const cs = createComponentStore(userState);
+
+        const spy = jest.fn();
+        cs.select().subscribe(spy);
+        expect(spy).toHaveBeenCalledWith(userState);
+        expect(spy).toHaveBeenCalledTimes(1);
+
+        spy.mockReset();
+
+        cs.setState(() => ({ firstName: 'Nicolas' }));
+        expect(spy).toHaveBeenCalledWith({ ...userState, firstName: 'Nicolas' });
+        expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should update state using an Observable', () => {
+        const cs = createComponentStore(counterInitialState);
+
+        const counterState$: Observable<CounterState> = of(2, 3, 4, 5).pipe(
+            map((v) => ({ counter: v }))
+        );
+
+        const subscribeCallback = jest.fn<void, [number]>();
+        cs.select((state) => state.counter).subscribe(subscribeCallback);
+
+        // setState with Observable
+        cs.setState(counterState$);
+
+        // "normal" setState
+        cs.setState((state) => ({ counter: state.counter + 1 }));
+        cs.setState((state) => ({ counter: state.counter + 1 }));
+
+        expect(subscribeCallback.mock.calls).toEqual([[1], [2], [3], [4], [5], [6], [7]]);
+    });
+
+    it('should select state with memoized selectors', () => {
+        const getCounterSpy = jest.fn<void, [number]>();
+        const getSquareCounterSpy = jest.fn<void, [number]>();
+
+        const cs = createComponentStore(counterInitialState);
+
+        const getComponentState = createComponentStateSelector<CounterState>();
+        const getCounter = createSelector(getComponentState, (state) => {
+            getCounterSpy(state.counter);
+            return state.counter;
+        });
+        const getSquareCounter = createSelector(getCounter, (counter) => {
+            getSquareCounterSpy(counter);
+            return counter * 2;
+        });
+
+        cs.select(getSquareCounter).subscribe();
+
+        cs.setState({ counter: 2 });
+        cs.setState({ counter: 2 });
+        cs.setState({ counter: 3 });
+        cs.setState({ counter: 3 });
+        cs.setState({ counter: 4 });
+
+        expect(getCounterSpy.mock.calls).toEqual([[1], [2], [2], [3], [3], [4]]); // No memoization: because a new state object is created for every call of `setState`
+        expect(getSquareCounterSpy.mock.calls).toEqual([[1], [2], [3], [4]]);
+    });
+
+    it('should select component state with the `state$` property', () => {
+        const spy = jest.fn();
+
+        const cs = createComponentStore(counterInitialState);
+        cs.state$.subscribe(spy);
+
+        expect(spy).toHaveBeenCalledWith(counterInitialState);
+    });
+
+    it('should dispatch an Action when updating state', () => {
+        const cs = createComponentStore(counterInitialState);
+
+        const spy = jest.fn();
+        cs['actionsOnQueue'].actions$.subscribe(spy);
+
+        const setStateCallback = (state: CounterState) => ({ counter: state.counter + 1 });
+        cs.setState(setStateCallback);
+        expect(spy).toHaveBeenCalledWith({
+            setStateActionType: '@mini-rx/component-store',
+            type: '@mini-rx/component-store/set-state',
+            stateOrCallback: setStateCallback,
+        });
+        expect(spy).toHaveBeenCalledTimes(1);
+
+        spy.mockReset();
+
+        // With setState name
+        cs.setState(setStateCallback, 'increment');
+        expect(spy).toHaveBeenCalledWith({
+            setStateActionType: '@mini-rx/component-store',
+            type: '@mini-rx/component-store/set-state/increment',
+            stateOrCallback: setStateCallback,
+        });
+        expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should unsubscribe from setState Observable on destroy', () => {
+        const cs = createComponentStore(counterInitialState);
+
+        const counterSource = new Subject<number>();
+        const counterState$: Observable<CounterState> = counterSource.pipe(
+            map((v) => ({ counter: v }))
+        );
+
+        const subscribeCallback = jest.fn<void, [number]>();
+        cs.select((state) => state.counter).subscribe(subscribeCallback);
+
+        cs.setState(counterState$);
+
+        counterSource.next(1);
+        counterSource.next(2);
+
+        cs.destroy();
+
+        counterSource.next(3);
+
+        expect(subscribeCallback.mock.calls).toEqual([[1], [2]]);
+    });
+
+    it('should unsubscribe an effect on destroy', () => {
+        const effectCallback = jest.fn<void, [number]>();
+
+        const cs = createComponentStore(counterInitialState);
+        const myEffect = cs.effect<number>(pipe(tap((v) => effectCallback(v))));
+
+        const counterSource = new Subject<number>();
+
+        // Trigger effect with the counterSource Subject
+        myEffect(counterSource);
+
+        counterSource.next(1);
+        counterSource.next(2);
+
+        // Trigger effect imperatively (just to cover both ways to trigger an effect)
+        myEffect(3);
+        myEffect(4);
+
+        cs.destroy();
+
+        counterSource.next(5);
+        myEffect(6);
+
+        expect(effectCallback.mock.calls).toEqual([[1], [2], [3], [4]]);
+    });
+
+    it('should initialize the store lazily', () => {
+        const cs = createComponentStore();
+
+        const spy = jest.fn();
+        cs.select().subscribe(spy);
+        expect(spy).toHaveBeenCalledTimes(0);
+
+        cs.setInitialState(counterInitialState);
+        expect(spy).toHaveBeenCalledWith(counterInitialState);
+        expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should update state of the lazily initialized store', () => {
+        const cs = createComponentStore<CounterState>();
+
+        const spy = jest.fn();
+        cs.select().subscribe(spy);
+        expect(spy).toHaveBeenCalledTimes(0);
+
+        spy.mockReset();
+
+        cs.setInitialState(counterInitialState);
+        expect(spy).toHaveBeenCalledWith(counterInitialState);
+        expect(spy).toHaveBeenCalledTimes(1);
+
+        spy.mockReset();
+
+        cs.setState((state) => ({ counter: state.counter + 1 }));
+        expect(spy).toHaveBeenCalledWith({ counter: 2 });
+        expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw when accessing not initialized state', () => {
+        const cs = createComponentStore();
+        expect(() => cs.state).toThrowError(
+            '@mini-rx: ComponentStore has no initialState yet. Please provide an initialState before updating/getting state.'
+        );
+    });
+
+    it('should throw when updating state and no initial state was provided', () => {
+        const cs = createComponentStore();
+        expect(() => cs.setState((state) => state)).toThrowError(
+            '@mini-rx: ComponentStore has no initialState yet. Please provide an initialState before updating/getting state.'
+        );
+    });
+
+    it('should throw when calling setInitialState, but initial state was provided already', () => {
+        const cs = createComponentStore(counterInitialState);
+        expect(() => cs.setInitialState(counterInitialState)).toThrowError(
+            '@mini-rx: ComponentStore has initialState already.'
+        );
+
+        const cs2 = createComponentStore();
+        cs2.setInitialState(counterInitialState);
+        expect(() => cs.setInitialState(counterInitialState)).toThrowError(
+            '@mini-rx: ComponentStore has initialState already.'
+        );
+    });
+
+    it('should throw when calling `configureComponentStores` more than once', () => {
+        configureComponentStores({ extensions: [] });
+        expect(() => configureComponentStores({ extensions: [] })).toThrowError(
+            '@mini-rx: `configureComponentStores` was called multiple times.'
+        );
+    });
+
+    it('should throw when using undo without extension', () => {
+        const cs = createComponentStore();
+
+        expect(() => cs.undo({ type: 'someType' })).toThrowError(
+            '@mini-rx: ComponentStore has no UndoExtension yet.'
+        );
+    });
+
+    it('should throw when a not supported extension is used', () => {
+        class MyExtension extends StoreExtension {
+            id: ExtensionId = ExtensionId.LOGGER;
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
+            init(): void {}
+        }
+
+        expect(() =>
+            createComponentStore(undefined, {
+                extensions: [new MyExtension() as ComponentStoreExtension],
+            })
+        ).toThrowError('@mini-rx: Extension "MyExtension" is not supported by Component Store.');
+    });
+
+    describe('Extensions', () => {
+        beforeEach(() => {
+            _resetConfig();
+        });
+
+        it('should be local', () => {
+            const extensions = [new LoggerExtension(), new UndoExtension()];
+            const cs = createComponentStore(undefined, { extensions });
+
+            expect(cs['extensions']).toBe(extensions);
+        });
+
+        it('should be global', () => {
+            const extensions = [new LoggerExtension(), new UndoExtension()];
+
+            configureComponentStores({ extensions });
+            const cs = createComponentStore(undefined);
+
+            expect(cs['extensions']).toBe(extensions);
+        });
+
+        it('should be merged', () => {
+            const globalExtensions = [new LoggerExtension(), new ImmutableStateExtension()];
+            const localExtensions = [new UndoExtension()];
+
+            configureComponentStores({ extensions: globalExtensions });
+            const cs = createComponentStore(undefined, { extensions: localExtensions });
+
+            expect(cs['extensions'][0]).toBe(localExtensions[0]);
+            expect(cs['extensions'][1]).toBe(globalExtensions[0]);
+            expect(cs['extensions'][2]).toBe(globalExtensions[1]);
+        });
+
+        it('should be merged (use local if extension is used globally and locally)', () => {
+            const globalExtensions = [new LoggerExtension(), new ImmutableStateExtension()];
+            const localExtensions = [new LoggerExtension()];
+
+            configureComponentStores({ extensions: globalExtensions });
+            const cs = createComponentStore(undefined, { extensions: localExtensions });
+
+            expect(cs['extensions'][0]).toBe(localExtensions[0]);
+            expect(cs['extensions'][1]).toBe(globalExtensions[1]);
+        });
+    });
+});

--- a/libs/mini-rx-store/src/lib/spec/immutable-state.extension.spec.ts
+++ b/libs/mini-rx-store/src/lib/spec/immutable-state.extension.spec.ts
@@ -1,12 +1,20 @@
 import { counterInitialState, CounterState, store } from './_spec-helpers';
-import { ImmutableStateExtension, storeFreeze } from '../extensions/immutable-state.extension';
-import { Action, Reducer } from '../models';
+import { ImmutableStateExtension } from '../extensions/immutable-state.extension';
+import { Action, MetaReducer, Reducer } from '../models';
 import { createFeatureSelector } from '../selector';
 import { createFeatureStore, FeatureStore } from '../feature-store';
-import StoreCore from '../store-core';
+import { addExtension } from '../store-core';
+import { createComponentStore } from '../component-store';
+
+// Return a fresh (shallow) copy
+function getCounterInitialState() {
+    return {
+        ...counterInitialState,
+    };
+}
 
 export function counterReducerWithMutation(
-    state: CounterState = counterInitialState,
+    state: CounterState = getCounterInitialState(),
     action: Action
 ) {
     switch (action.type) {
@@ -27,6 +35,7 @@ export function counterReducerWithMutation(
 }
 
 describe('Store Freeze Meta Reducer', () => {
+    const storeFreeze: MetaReducer<any> = new ImmutableStateExtension().init(); // init returns the storeFreeze Meta Reducer
     const frozenReducer: Reducer<CounterState> = storeFreeze(counterReducerWithMutation);
 
     it('should not throw', () => {
@@ -71,10 +80,13 @@ describe('Immutable State Extension', () => {
     const featureSelector = createFeatureSelector<CounterState>('immutableCounter2');
     let counterStateRaw: CounterState;
 
-    const fs: FeatureStore<CounterState> = createFeatureStore('fsImmutable', counterInitialState);
+    const fs: FeatureStore<CounterState> = createFeatureStore(
+        'fsImmutable',
+        getCounterInitialState()
+    );
 
     beforeAll(() => {
-        StoreCore.addExtension(new ImmutableStateExtension());
+        addExtension(new ImmutableStateExtension());
         store.feature<CounterState>('immutableCounter2', counterReducerWithMutation);
         store.select(featureSelector).subscribe((state) => (counterStateRaw = state));
     });
@@ -103,28 +115,85 @@ describe('Immutable State Extension', () => {
 
         // Strangely the following expect does not throw
         // Why does Jest not detect the error (ERROR TypeError: Cannot assign to read only property 'xyz' of object '[object Object]')?
+        // It throws in the Browser!
         // expect(() => store.dispatch({type: 'counterWithMutation'})).toThrow();
 
-        // However when mutating the state it does not emit a new state
+        // Work around: However when mutating the state it does not emit a new state (I believe because of the exception)
         store.dispatch({ type: 'counterWithMutation' });
         expect(spy).toHaveBeenCalledTimes(0);
     });
 
-    it('should throw when mutating state in a FeatureStore', () => {
-        function updateCount() {
-            const state = fs.state;
-            state.counter = 123;
-        }
-
-        expect(() => updateCount()).toThrow(TypeError);
-        expect(() => (fs.state.counter = 123)).toThrow(TypeError);
-    });
-
-    it('should throw when mutating selected state from a FeatureStore', () => {
+    it('should throw when mutating state from a FeatureStore', () => {
         let selectedFeatureState: CounterState;
 
         fs.select().subscribe((state) => (selectedFeatureState = state));
 
         expect(() => (selectedFeatureState.counter = 123)).toThrow();
+        expect(() => (fs.state.counter = 123)).toThrow();
+    });
+
+    it('should throw when mutating state inside a FeatureStore reducer', () => {
+        const spy = jest.fn();
+
+        fs.select().subscribe(spy);
+
+        spy.mockReset();
+
+        // Strangely the following expect does not throw
+        // Why does Jest not detect the error (ERROR TypeError: Cannot assign to read only property 'xyz' of object '[object Object]')?
+        // It throws in the Browser!
+        // expect(() =>
+        //     fs.setState((state) => {
+        //         state.counter = 123;
+        //         return state;
+        //     })
+        // ).toThrow();
+
+        // Work around: However when mutating the state it does not emit a new state (I believe because of the exception)
+        fs.setState((state) => {
+            state.counter = 123;
+            return state;
+        });
+
+        expect(spy).toHaveBeenCalledTimes(0);
+    });
+});
+
+describe('Immutable State Extension and ComponentStore', () => {
+    it('should throw when mutating state from a ComponentStore', () => {
+        const cs = createComponentStore(getCounterInitialState(), {
+            extensions: [new ImmutableStateExtension()],
+        });
+
+        let selectedComponentState: CounterState;
+
+        cs.select().subscribe((state) => (selectedComponentState = state));
+
+        expect(() => (selectedComponentState.counter = 123)).toThrow();
+        expect(() => (cs.state.counter = 123)).toThrow();
+
+        // Strangely the following expect does not throw
+        // Why does Jest not detect the error (ERROR TypeError: Cannot assign to read only property 'xyz' of object '[object Object]')?
+        // It throws in the Browser!
+        // expect(() =>
+        //     cs.setState((state) => {
+        //         state.counter = 123;
+        //         return state;
+        //     })
+        // ).toThrow();
+
+        // Work around: However when mutating the state it does not emit a new state (I believe because of the exception)
+        const spy = jest.fn();
+        cs.select().subscribe(spy);
+        spy.mockReset();
+
+        cs.setState((state) => {
+            state.counter = 123;
+            return {
+                counter: state.counter + 1,
+            };
+        });
+
+        expect(spy).toHaveBeenCalledTimes(0);
     });
 });

--- a/libs/mini-rx-store/src/lib/spec/logger.extension.spec.ts
+++ b/libs/mini-rx-store/src/lib/spec/logger.extension.spec.ts
@@ -1,7 +1,8 @@
 import { counterReducer, resetStoreConfig, userState } from './_spec-helpers';
-import StoreCore from '../store-core';
 import { LoggerExtension } from '../extensions/logger.extension';
 import { createFeatureStore } from '../feature-store';
+import { addFeature, configureStore, dispatch } from '../store-core';
+import { createComponentStore } from '../component-store';
 
 describe('LoggerExtension', () => {
     console.log = jest.fn();
@@ -9,17 +10,17 @@ describe('LoggerExtension', () => {
     beforeEach(() => {
         resetStoreConfig();
 
-        StoreCore.config({
+        configureStore({
             extensions: [new LoggerExtension()],
         });
     });
 
     it('should log a dispatched Action', () => {
-        StoreCore.addFeature('counter', counterReducer);
+        addFeature('counter', counterReducer);
 
         const action = { type: 'counter' };
 
-        StoreCore.dispatch(action);
+        dispatch(action);
 
         expect(console.log).toHaveBeenCalledWith(
             expect.stringContaining('counter'),
@@ -54,6 +55,46 @@ describe('LoggerExtension', () => {
                     ...userState,
                     firstName: 'Cage',
                 },
+            }
+        );
+    });
+});
+
+describe('LoggerExtension with ComponentStore', () => {
+    it('should log a SetStateAction with only type and payload', () => {
+        console.log = jest.fn();
+
+        const cs = createComponentStore(userState, { extensions: [new LoggerExtension()] });
+
+        expect(console.log).toHaveBeenCalledWith(
+            expect.stringContaining('@mini-rx/component-store/init'),
+            expect.stringContaining('color: #25c2a0'),
+            expect.stringContaining('Action:'),
+            {
+                type: '@mini-rx/component-store/init',
+            },
+            expect.stringContaining('State:'),
+            userState
+        );
+
+        cs.setState((state) => ({
+            firstName: 'Cage',
+        }));
+
+        expect(console.log).toHaveBeenCalledWith(
+            expect.stringContaining('@mini-rx/component-store/set-state'),
+            expect.stringContaining('color: #25c2a0'),
+            expect.stringContaining('Action:'),
+            {
+                type: '@mini-rx/component-store/set-state',
+                payload: {
+                    firstName: 'Cage',
+                },
+            },
+            expect.stringContaining('State: '),
+            {
+                ...userState,
+                firstName: 'Cage',
             }
         );
     });

--- a/libs/mini-rx-store/src/lib/spec/redux-devtools.extension.spec.ts
+++ b/libs/mini-rx-store/src/lib/spec/redux-devtools.extension.spec.ts
@@ -1,4 +1,3 @@
-import StoreCore from '../store-core';
 import {
     ReduxDevtoolsExtension,
     ReduxDevtoolsOptions,
@@ -6,6 +5,7 @@ import {
 import { Action } from '../models';
 import { counterReducer, CounterState, store, userState, UserState } from './_spec-helpers';
 import { createFeatureStore, FeatureStore } from '../feature-store';
+import { addExtension, appState } from '../store-core';
 
 const win = window as any;
 JSON.parse = jest.fn().mockImplementationOnce((data) => {
@@ -51,7 +51,7 @@ describe('Redux Dev Tools', () => {
         };
 
         extension = new ReduxDevtoolsExtension(options);
-        StoreCore.addExtension(extension);
+        addExtension(extension);
 
         expect(connectFn).toHaveBeenCalledTimes(1);
         expect(connectFn).toHaveBeenCalledWith(options);
@@ -98,7 +98,7 @@ describe('Redux Dev Tools', () => {
     });
 
     it('should update the Store state', () => {
-        const spy = jest.spyOn(StoreCore, 'updateState');
+        const spy = jest.spyOn(appState, 'set');
 
         extension['onDevToolsMessage']({
             type: 'DISPATCH',

--- a/libs/mini-rx-store/src/lib/spec/selector.spec.ts
+++ b/libs/mini-rx-store/src/lib/spec/selector.spec.ts
@@ -33,9 +33,7 @@ describe('Selectors', () => {
         it('should deliver the value of selectors to the projection function', () => {
             const projectFn = jasmine.createSpy('projectionFn');
 
-            const selector = createSelector(incrementOne, incrementTwo, projectFn)(
-                {}
-            );
+            const selector = createSelector(incrementOne, incrementTwo, projectFn)({});
 
             expect(projectFn).toHaveBeenCalledWith(countOne, countTwo);
         });
@@ -61,12 +59,7 @@ describe('Selectors', () => {
             const firstState = { first: 'state' };
             const secondState = { second: 'state' };
             const projectFn = jasmine.createSpy('projectionFn');
-            const selector = createSelector(
-                incrementOne,
-                incrementTwo,
-                incrementThree,
-                projectFn
-            );
+            const selector = createSelector(incrementOne, incrementTwo, incrementThree, projectFn);
 
             selector(firstState);
             selector(firstState);
@@ -90,7 +83,10 @@ describe('Selectors', () => {
                 .createSpy('projectorFn', (s: any) => (s.ok ? s.ok : fail()))
                 .and.callThrough();
             const selectorFn = jasmine
-                .createSpy('selectorFn', createSelector(state => state, projectorFn))
+                .createSpy(
+                    'selectorFn',
+                    createSelector((state) => state, projectorFn)
+                )
                 .and.callThrough();
 
             selectorFn(firstState);

--- a/libs/mini-rx-store/src/lib/spec/utils.spec.ts
+++ b/libs/mini-rx-store/src/lib/spec/utils.spec.ts
@@ -1,7 +1,7 @@
-import { actions$ } from '../store';
 import { ofType } from '../utils';
 import { Action } from '../models';
 import { store } from './_spec-helpers';
+import { actions$ } from '../store-core';
 
 const action1: Action = {
     type: 'updateUser',

--- a/libs/mini-rx-store/src/lib/state.ts
+++ b/libs/mini-rx-store/src/lib/state.ts
@@ -1,0 +1,43 @@
+import { BehaviorSubject, Observable } from 'rxjs';
+import { filter } from 'rxjs/operators';
+import { calcNewState, select } from './utils';
+import { StateOrCallback } from './models';
+
+export class State<StateType extends object> {
+    private stateSource: BehaviorSubject<StateType | undefined> = new BehaviorSubject<
+        StateType | undefined
+    >(this.initialState);
+    state$: Observable<StateType> = this.stateSource.asObservable().pipe(
+        // Skip the first (undefined) value of the BehaviorSubject
+        // Very similar to a ReplaySubject(1), but more lightweight
+        // Emits a state object (when calling the `set` method)
+        filter((v) => !!v)
+    ) as Observable<StateType>;
+
+    constructor(private initialState?: StateType) {}
+
+    get(): StateType | undefined {
+        return this.stateSource.value;
+    }
+
+    set(v: StateType) {
+        this.stateSource.next(v);
+    }
+
+    patch(stateOrCallback: StateOrCallback<StateType>) {
+        if (!this.get()) {
+            throw new Error('State is not initialized.');
+        }
+
+        this.stateSource.next(calcNewState(this.get()!, stateOrCallback));
+    }
+
+    select(): Observable<StateType>;
+    select<R>(mapFn: (state: StateType) => R): Observable<R>;
+    select(mapFn?: any): Observable<any> {
+        if (!mapFn) {
+            return this.state$;
+        }
+        return this.state$.pipe(select(mapFn));
+    }
+}

--- a/libs/mini-rx-store/src/lib/utils.ts
+++ b/libs/mini-rx-store/src/lib/utils.ts
@@ -2,12 +2,15 @@ import { Observable, OperatorFunction, pipe } from 'rxjs';
 import { distinctUntilChanged, filter, map } from 'rxjs/operators';
 import {
     Action,
-    ActionWithPayload,
     AppState,
     EFFECT_METADATA_KEY,
     HasEffectMetadata,
+    MetaReducer,
+    Reducer,
+    StateOrCallback,
+    StoreExtension,
 } from './models';
-import { isSetStateAction, SetStateAction } from './actions';
+import { isComponentStoreSetStateAction, isFeatureStoreSetStateAction } from './actions';
 import { miniRxNameSpace } from './constants';
 
 export function ofType(...allowedTypes: string[]): OperatorFunction<Action, Action> {
@@ -29,35 +32,55 @@ export function miniRxConsoleError(message: string, err: any): void {
     console.error(miniRxNameSpace + ': ' + message + '\nDetails:', err);
 }
 
-/** @internal */
 export function hasEffectMetaData(
     param: Observable<Action>
 ): param is Observable<Action> & HasEffectMetadata {
+    // eslint-disable-next-line no-prototype-builtins
     return param.hasOwnProperty(EFFECT_METADATA_KEY);
 }
 
-// Simple alpha numeric ID: https://stackoverflow.com/a/12502559/453959
-// This isn't a real GUID!
-export function generateId() {
-    return Math.random().toString(36).slice(2);
-}
-
-export function beautifyActionForLogging(action: Action, state: AppState): Action {
-    if (isSetStateAction(action)) {
-        return mapSetStateActionToActionWithPayload(action, state);
+// Calculate the setState callback and remove internal properties (only display type and payload in the LoggingExtension and Redux DevTools)
+export function beautifyActionForLogging(action: Action, state: object): Action {
+    if (isFeatureStoreSetStateAction(action)) {
+        const featureState = (state as AppState)[action.featureKey];
+        return {
+            type: action.type,
+            payload: calcNewPartialState(featureState, action.stateOrCallback),
+        };
+    } else if (isComponentStoreSetStateAction(action)) {
+        return {
+            type: action.type,
+            payload: calcNewPartialState(state, action.stateOrCallback),
+        };
     }
     return action;
 }
 
-function mapSetStateActionToActionWithPayload(
-    action: SetStateAction<any>,
-    state: AppState
-): ActionWithPayload {
-    const stateOrCallback = action.stateOrCallback;
-    const featureState = state[action.featureKey];
+function calcNewPartialState<T>(state: T, stateOrCallback: StateOrCallback<T>): Partial<T> {
+    return typeof stateOrCallback === 'function' ? stateOrCallback(state) : stateOrCallback;
+}
+
+export function calcNewState<T>(state: T, stateOrCallback: StateOrCallback<T>): T {
+    const newPartialState = calcNewPartialState(state, stateOrCallback);
     return {
-        type: action.type,
-        payload:
-            typeof stateOrCallback === 'function' ? stateOrCallback(featureState) : stateOrCallback,
+        ...state,
+        ...newPartialState,
     };
+}
+
+export function combineMetaReducers<T>(metaReducers: MetaReducer<T>[]): MetaReducer<T> {
+    return (reducer: Reducer<any>): Reducer<T> => {
+        return metaReducers.reduceRight(
+            (previousValue: Reducer<T>, currentValue: MetaReducer<T>) => {
+                return currentValue(previousValue);
+            },
+            reducer
+        );
+    };
+}
+
+export function sortExtensions<T extends StoreExtension>(extensions: T[]): T[] {
+    return [...extensions].sort((a, b) => {
+        return a.sortOrder - b.sortOrder;
+    });
 }

--- a/libs/mini-rx-store/tsconfig.lib.json
+++ b/libs/mini-rx-store/tsconfig.lib.json
@@ -1,10 +1,11 @@
 {
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "outDir": "../../dist/out-tsc",
-    "declaration": true,
-    "types": []
-  },
-  "include": ["**/*.ts"],
-  "exclude": ["src/lib/spec/**/*"]
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../dist/out-tsc",
+        "declaration": true,
+        "types": [],
+        "stripInternal": true
+    },
+    "include": ["**/*.ts"],
+    "exclude": ["src/lib/spec/**/*"]
 }


### PR DESCRIPTION
...lazy state initialisation (setInitialState), setState with Observable, tree-shakable

Refactor of StoreCore: refactor from class to functions to make MiniRx more tree-shakable New demo: "PixelArt" show-casing Component Store
Deprecations: createFeatureSelector -> use createFeatureStateSelector instead

BREAKING CHANGE: configureStore does not return a Store instance, it returns an object