### PR TITLE
fix(mini-rx-store): remove setstate callback calculation (for loggere…

### DIFF
--- a/libs/mini-rx-store/CHANGELOG.md
+++ b/libs/mini-rx-store/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [5.0.0-alpha.3](https://github.com/spierala/mini-rx-store/compare/mini-rx-store-5.0.0-alpha.2...mini-rx-store-5.0.0-alpha.3) (2023-03-21)
+
+
+### Bug Fixes
+
+* **mini-rx-store:** remove setstate callback calculation (for loggerextension and redux devtools) ([291987c](https://github.com/spierala/mini-rx-store/commit/291987cf9a3fb5a7ca9d1a3c5703c4189c50cfbf))
+
 ## [5.0.0-alpha.2](https://github.com/spierala/mini-rx-store/compare/mini-rx-store-5.0.0-alpha.1...mini-rx-store-5.0.0-alpha.2) (2023-02-03)
 
 ## [5.0.0-alpha.1](https://github.com/spierala/mini-rx-store/compare/mini-rx-store-5.0.0-alpha.0...mini-rx-store-5.0.0-alpha.1) (2023-02-01)

--- a/libs/mini-rx-store/package.json
+++ b/libs/mini-rx-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mini-rx-store",
-  "version": "5.0.0-alpha.2",
+  "version": "5.0.0-alpha.3",
   "author": "Florian Spier <mail@florian-spier.be> (https://florian-spier.be)",
   "license": "MIT",
   "homepage": "https://github.com/spierala/mini-rx-store",

--- a/libs/mini-rx-store/src/lib/spec/logger.extension.spec.ts
+++ b/libs/mini-rx-store/src/lib/spec/logger.extension.spec.ts
@@ -34,10 +34,11 @@ describe('LoggerExtension', () => {
 
     it('should log a SetStateAction with only type and payload', () => {
         const fs = createFeatureStore('user', userState);
-
-        fs.setState((state) => ({
+        const setStateCallback = () => ({
             firstName: 'Cage',
-        }));
+        });
+
+        fs.setState(setStateCallback);
 
         expect(console.log).toHaveBeenCalledWith(
             expect.stringContaining('@mini-rx/user/set-state'),
@@ -45,9 +46,7 @@ describe('LoggerExtension', () => {
             expect.stringContaining('Action:'),
             {
                 type: '@mini-rx/user/set-state',
-                payload: {
-                    firstName: 'Cage',
-                },
+                payload: setStateCallback,
             },
             expect.stringContaining('State: '),
             {
@@ -77,9 +76,11 @@ describe('LoggerExtension with ComponentStore', () => {
             userState
         );
 
-        cs.setState((state) => ({
+        const setStateCallback = () => ({
             firstName: 'Cage',
-        }));
+        });
+
+        cs.setState(setStateCallback);
 
         expect(console.log).toHaveBeenCalledWith(
             expect.stringContaining('@mini-rx/component-store/set-state'),
@@ -87,9 +88,7 @@ describe('LoggerExtension with ComponentStore', () => {
             expect.stringContaining('Action:'),
             {
                 type: '@mini-rx/component-store/set-state',
-                payload: {
-                    firstName: 'Cage',
-                },
+                payload: setStateCallback,
             },
             expect.stringContaining('State: '),
             {

--- a/libs/mini-rx-store/src/lib/spec/redux-devtools.extension.spec.ts
+++ b/libs/mini-rx-store/src/lib/spec/redux-devtools.extension.spec.ts
@@ -71,9 +71,11 @@ describe('Redux DevTools', () => {
     });
 
     it('should receive state and a SetStateAction with only type and payload', () => {
-        fs.setState((state) => ({
+        const setStateCallback = () => ({
             firstName: 'Cage',
-        }));
+        });
+
+        fs.setState(setStateCallback);
 
         let currAppState = {};
         store.select((state) => state).subscribe((state) => (currAppState = state));
@@ -82,9 +84,7 @@ describe('Redux DevTools', () => {
         expect(sendFn).toHaveBeenCalledWith(
             {
                 type: '@mini-rx/user/set-state',
-                payload: {
-                    firstName: 'Cage',
-                },
+                payload: setStateCallback,
             },
             {
                 ...currAppState,


### PR DESCRIPTION
…xtension and redux devtools)

The calculation of the setState callback result  caused many executions of the setState callback. This behavior is confusing and unexpected when debugging setState callbacks e.g. with a breakpoint. Trade-off of the fix:
- The logging is less informative when using setState callbacks
- We can only see that the action payload  is a function (LoggerExtension),
- Redux DevTools do not show the payload if it is a function