### PR TITLE
refactor(all): Change npm commands since yarn is the default package manager

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,24 +7,24 @@ MiniRx Store uses [NX](https://nx.dev/) to manage several libraries and apps in 
 
 Install the dependencies:
 ```shell
-npm i
+yarn install
 ```
 
 ## Run
 
 Start the demo app with a watcher on the app and library code.
 ```shell
-npm run dev
+yarn dev
 ```
 
 ## Test
 
 ```shell
-npm run test:mini-rx-store:watch
+yarn test:mini-rx-store:watch
 ```
 
 ```shell
-npm run test:mini-rx-store-ng:watch
+yarn test:mini-rx-store-ng:watch
 ```
 
 ## Questions and requests for support

--- a/apps/mini-rx-angular-demo/README.md
+++ b/apps/mini-rx-angular-demo/README.md
@@ -20,11 +20,11 @@ This demo uses both the Redux API and the Feature Store API:
 
 ### Install dependencies
 
-`npm install`
+`yarn install`
 
 ### Run the demo
 
-`npm run start:angular-demo`
+`yarn start:angular-demo`
 
 ### NX
 

--- a/nx.json
+++ b/nx.json
@@ -4,7 +4,7 @@
         "defaultBase": "main"
     },
     "cli": {
-        "packageManager": "npm"
+        "packageManager": "yarn"
     },
     "tasksRunnerOptions": {
         "default": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "test:mini-rx-store-ng": "nx test mini-rx-store-ng",
         "test:mini-rx-store-ng:watch": "nx test mini-rx-store-ng --watch",
         "test:mini-rx-store-ng:coverage": "nx test mini-rx-store-ng --codeCoverage",
-        "deploy:docs": "cd docs && yarn deploy && cd ..",
+        "deploy:docs": "cd docs && yarn deploy",
         "build:mini-rx-angular-demo:sourcemap": "nx build mini-rx-angular-demo --source-map",
         "build:mini-rx-angular-demo:sourcemap:stats": "yarn build:mini-rx-angular-demo:sourcemap && source-map-explorer dist/apps/mini-rx-angular-demo/**/*.js",
         "prepare": "husky install"

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
         "test:mini-rx-store-ng": "nx test mini-rx-store-ng",
         "test:mini-rx-store-ng:watch": "nx test mini-rx-store-ng --watch",
         "test:mini-rx-store-ng:coverage": "nx test mini-rx-store-ng --codeCoverage",
-        "deploy:docs": "npm run deploy --prefix docs",
+        "deploy:docs": "cd docs && yarn deploy && cd ..",
         "build:mini-rx-angular-demo:sourcemap": "nx build mini-rx-angular-demo --source-map",
-        "build:mini-rx-angular-demo:sourcemap:stats": "npm run build:mini-rx-angular-demo:sourcemap && source-map-explorer dist/apps/mini-rx-angular-demo/**/*.js",
+        "build:mini-rx-angular-demo:sourcemap:stats": "yarn build:mini-rx-angular-demo:sourcemap && source-map-explorer dist/apps/mini-rx-angular-demo/**/*.js",
         "prepare": "husky install"
     },
     "private": true,


### PR DESCRIPTION
@spierala I didn't change (or add to) any of the npm commands for users installing (dependencies related to) `mini-rx-store`, because I assume that was not in scope. If it would be, let me know and I could add the yarn commands next to the npm ones.