### PR TITLE
refactor(signal-store): deprecate the `state` property for ComponentS…

### DIFF
--- a/libs/signal-store/src/lib/component-store.ts
+++ b/libs/signal-store/src/lib/component-store.ts
@@ -35,6 +35,12 @@ export class ComponentStore<StateType extends object> implements ComponentStoreL
 
     private _state: WritableSignal<StateType> = signal(this.initialState);
     private selectableState = createSelectableSignalState(this._state);
+
+    /**
+     * @deprecated
+     * Use the `select` method without arguments to return a state Signal
+     * the `state` property will be replaced with a getter function which returns the raw state (like in the original MiniRx Store)
+     */
     state: Signal<StateType> = this.selectableState.select();
 
     private updateState: UpdateStateCallback<StateType> = (

--- a/libs/signal-store/src/lib/feature-store.ts
+++ b/libs/signal-store/src/lib/feature-store.ts
@@ -26,6 +26,11 @@ export class FeatureStore<StateType extends object> implements ComponentStoreLik
         return this._featureKey;
     }
 
+    /**
+     * @deprecated
+     * Use the `select` method without arguments to return a state Signal
+     * the `state` property will be replaced with a getter function which returns the raw state (like in the original MiniRx Store)
+     */
     state: Signal<StateType> = select((state) => state[this.featureKey]);
 
     private updateState: UpdateStateCallback<StateType> = (


### PR DESCRIPTION
…tore and FeatureStore

DEPRECATED: `state` property

If the state is needed as Signal, the `select` method can be used without arguments. In the future there will be a `state` getter function which returns the raw state. This will be more in line with the original MiniRx Store.