### PR TITLE
refactor(common): refactor generateId to use Nano ID implementation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -75,3 +75,7 @@ See the file for details.
 This repository includes a file "mini-rx-to-observable.ts" originally copied from
 https://github.com/angular/angular/blob/16.2.10/packages/core/rxjs-interop/src/to_observable.ts, MIT style licensed.
 See the file for details.
+
+This repository includes a file "generate-id.ts" originally copied from
+https://github.com/ai/nanoid/blob/main/non-secure/index.js, MIT licensed.
+See the file for details.

--- a/libs/common/src/lib/generate-id.spec.ts
+++ b/libs/common/src/lib/generate-id.spec.ts
@@ -1,25 +1,10 @@
 import { generateId, urlAlphabet } from './generate-id';
 
 describe('generateId', () => {
-    it('should generate an id of the given length', () => {
-        let id = generateId(1);
-
-        expect(id.length).toBe(1);
-
-        id = generateId(21);
-
-        expect(id.length).toBe(21);
-    });
-
     it('should generate an id of 6 characters long if no argument was passed', () => {
         const id = generateId();
 
         expect(id.length).toEqual(6);
-    });
-
-    it('should generate an id consisting of dashes, underscores, lowercase letters, uppercase letters or digits', () => {
-        const id = generateId(10);
-
         id.split('').forEach((char: string) => {
             expect(urlAlphabet.includes(char)).toBe(true);
         });

--- a/libs/common/src/lib/generate-id.spec.ts
+++ b/libs/common/src/lib/generate-id.spec.ts
@@ -1,7 +1,7 @@
 import { generateId, urlAlphabet } from './generate-id';
 
 describe('generateId', () => {
-    it('should generate an id of 6 characters long if no argument was passed', () => {
+    it('should generate an id of 6 characters long', () => {
         const id = generateId();
 
         expect(id.length).toEqual(6);

--- a/libs/common/src/lib/generate-id.spec.ts
+++ b/libs/common/src/lib/generate-id.spec.ts
@@ -1,0 +1,27 @@
+import { generateId, urlAlphabet } from './generate-id';
+
+describe('generateId', () => {
+    it('should generate an id of the given length', () => {
+        let id = generateId(1);
+
+        expect(id.length).toBe(1);
+
+        id = generateId(21);
+
+        expect(id.length).toBe(21);
+    });
+
+    it('should generate an id of 6 characters long if no argument was passed', () => {
+        const id = generateId();
+
+        expect(id.length).toEqual(6);
+    });
+
+    it('should generate an id consisting of dashes, underscores, lowercase letters, uppercase letters or digits', () => {
+        const id = generateId(10);
+
+        id.split('').forEach((char: string) => {
+            expect(urlAlphabet.includes(char)).toBe(true);
+        });
+    });
+});

--- a/libs/common/src/lib/generate-id.ts
+++ b/libs/common/src/lib/generate-id.ts
@@ -1,5 +1,16 @@
-// Simple alphanumeric ID: https://stackoverflow.com/a/12502559/453959
-// This isn't a real GUID!
-export function generateId(): string {
-    return Math.random().toString(36).slice(2);
+/*
+Implementation was copied from Nano ID (https://github.com/ai/nanoid)
+For more details, see LICENSE
+ */
+export const urlAlphabet = 'useandom-26T198340PX75pxJACKVERYMINDBUSHWOLF_GQZbfghjklqvwyzrict';
+
+export function generateId(size = 6): string {
+    let id = '';
+    // A compact alternative for `for (var i = 0; i < step; i++)`.
+    let i = size | 0;
+    while (i--) {
+        // `| 0` is more compact and faster than `Math.floor()`.
+        id += urlAlphabet[(Math.random() * 64) | 0];
+    }
+    return id;
 }

--- a/libs/common/src/lib/generate-id.ts
+++ b/libs/common/src/lib/generate-id.ts
@@ -1,13 +1,32 @@
-/*
-Implementation was copied from Nano ID (https://github.com/ai/nanoid)
-For more details, see LICENSE
- */
+/**
+ The MIT License (MIT)
+
+Copyright 2017 Andrey Sitnik <andrey@sitnik.ru>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+**/
 export const urlAlphabet = 'useandom-26T198340PX75pxJACKVERYMINDBUSHWOLF_GQZbfghjklqvwyzrict';
 
-export function generateId(size = 6): string {
+export function generateId(): string {
     let id = '';
+    // The desired length for a generated ID is 6 characters.
     // A compact alternative for `for (var i = 0; i < step; i++)`.
-    let i = size | 0;
+    let i = 6;
     while (i--) {
         // `| 0` is more compact and faster than `Math.floor()`.
         id += urlAlphabet[(Math.random() * 64) | 0];


### PR DESCRIPTION
Updated implementation for `generateId` due to the (very low) probability in the old implementation of throwing a SyntaxError if `Math.random` would return 0

Closes spierala/mini-rx-store#224 