### PR TITLE
fix(all): fix ESLint errors

### DIFF
--- a/apps/mini-rx-angular-demo/src/app/modules/products/components/product-detail/product-detail.component.ts
+++ b/apps/mini-rx-angular-demo/src/app/modules/products/components/product-detail/product-detail.component.ts
@@ -29,7 +29,7 @@ export class ProductDetailComponent {
     delete = new EventEmitter<Product>();
 
     @Output()
-    close = new EventEmitter<void>();
+    closed = new EventEmitter<void>();
 
     submit(form: NgForm) {
         const newProduct: Product = {

--- a/apps/mini-rx-angular-demo/src/app/modules/products/components/product-filter/product-filter.component.ts
+++ b/apps/mini-rx-angular-demo/src/app/modules/products/components/product-filter/product-filter.component.ts
@@ -33,8 +33,6 @@ export class ProductFilterComponent implements OnInit, OnDestroy {
         search: this.searchInput,
     });
 
-    constructor() {}
-
     ngOnInit(): void {
         this.searchInput.valueChanges
             .pipe(debounceTime(350), takeUntil(this.unsubscribe$))

--- a/apps/mini-rx-angular-demo/src/app/modules/products/models/cart-item.ts
+++ b/apps/mini-rx-angular-demo/src/app/modules/products/models/cart-item.ts
@@ -1,6 +1,6 @@
 export class CartItem {
     productId: number | undefined;
-    amount: number = 0;
+    amount = 0;
 
     // UI only
     productName?: string;

--- a/apps/mini-rx-angular-demo/src/app/modules/products/models/product.ts
+++ b/apps/mini-rx-angular-demo/src/app/modules/products/models/product.ts
@@ -1,9 +1,9 @@
 /* Defines the product entity */
 export class Product {
     id: number | undefined;
-    productName: string = '';
-    productCode: string = 'New';
-    description: string = '';
-    starRating: number = 0;
+    productName = '';
+    productCode = 'New';
+    description = '';
+    starRating = 0;
     price: number | undefined;
 }

--- a/apps/mini-rx-angular-demo/src/app/modules/products/services/products-api.service.ts
+++ b/apps/mini-rx-angular-demo/src/app/modules/products/services/products-api.service.ts
@@ -50,7 +50,7 @@ export class ProductsApiService {
         );
     }
 
-    deleteProduct(id: number): Observable<{}> {
+    deleteProduct(id: number): Observable<Product> {
         const headers = new HttpHeaders({ 'Content-Type': 'application/json' });
         const url = `${apiUrl}/${id}`;
         return this.http.delete<Product>(url, { headers }).pipe(

--- a/apps/mini-rx-angular-demo/src/app/modules/products/services/products-api.service.ts
+++ b/apps/mini-rx-angular-demo/src/app/modules/products/services/products-api.service.ts
@@ -54,7 +54,7 @@ export class ProductsApiService {
         const headers = new HttpHeaders({ 'Content-Type': 'application/json' });
         const url = `${apiUrl}/${id}`;
         return this.http.delete<Product>(url, { headers }).pipe(
-            tap((data) => {
+            tap(() => {
                 console.log('deleteProduct: ' + id);
                 this.toastr.success('Product deleted');
             }),

--- a/apps/mini-rx-angular-demo/src/app/modules/todos-shared/components/todo-detail/todo-detail.component.html
+++ b/apps/mini-rx-angular-demo/src/app/modules/todos-shared/components/todo-detail/todo-detail.component.html
@@ -1,7 +1,7 @@
 <div class="card h-100">
     <div class="card-header">
         <span>{{ todo.id ? 'Edit Todo' : 'Create Todo' }}</span>
-        <button (click)="close.emit()" type="button" class="close" aria-label="Close">
+        <button (click)="closed.emit()" type="button" class="close" aria-label="Close">
             <span aria-hidden="true">&times;</span>
         </button>
     </div>

--- a/apps/mini-rx-angular-demo/src/app/modules/todos-shared/components/todo-detail/todo-detail.component.ts
+++ b/apps/mini-rx-angular-demo/src/app/modules/todos-shared/components/todo-detail/todo-detail.component.ts
@@ -21,7 +21,7 @@ export class TodoDetailComponent {
     delete = new EventEmitter<Todo>();
 
     @Output()
-    close = new EventEmitter<void>();
+    closed = new EventEmitter<void>();
 
     submit() {
         if (this.todo.id) {

--- a/apps/mini-rx-angular-demo/src/app/modules/todos-shared/components/todo-filter/todo-filter.component.ts
+++ b/apps/mini-rx-angular-demo/src/app/modules/todos-shared/components/todo-filter/todo-filter.component.ts
@@ -37,8 +37,6 @@ export class TodoFilterComponent implements OnInit, OnDestroy {
 
     private unsubscribe$: Subject<void> = new Subject();
 
-    constructor() {}
-
     ngOnInit(): void {
         // Debounce just the text input
         this.formGroup

--- a/apps/mini-rx-angular-demo/src/app/modules/todos-shared/models/todo.ts
+++ b/apps/mini-rx-angular-demo/src/app/modules/todos-shared/models/todo.ts
@@ -1,7 +1,7 @@
 export class Todo {
     id: number | undefined;
-    title: string = '';
-    isDone: boolean = false;
+    title = '';
+    isDone = false;
     isBusiness?: boolean;
     isPrivate?: boolean;
     tempId?: string;

--- a/apps/mini-rx-angular-demo/src/app/modules/todos-simple/components/todos-simple-shell/todos-simple-shell.component.html
+++ b/apps/mini-rx-angular-demo/src/app/modules/todos-simple/components/todos-simple-shell/todos-simple-shell.component.html
@@ -2,7 +2,9 @@
     <nav class="navbar navbar-light bg-light mb-1">
         <a class="navbar-brand">Todos Simple</a>
         <div class="d-flex flex-grow-1 mb-2 justify-content-between mt-2">
-            <button class="btn btn-primary btn-sm" (click)="todosSimpleStore.initNewTodo()">New</button>
+            <button class="btn btn-primary btn-sm" (click)="todosSimpleStore.initNewTodo()">
+                New
+            </button>
             <app-filter
                 (filterUpdate)="todosSimpleStore.updateFilter($event)"
                 [filter]="(filter$ | async)!"
@@ -13,8 +15,11 @@
     <div class="m-3 alert alert-info d-flex align-items-center" role="alert">
         <i class="info-icon bi bi-info-circle-fill"></i>
         <div>
-            MiniRx <strong>Feature Store</strong> is used to manage the "Todos Simple" state.
-            Feature Store state becomes part of the <strong>global state</strong> object.
+            MiniRx
+            <strong>Feature Store</strong>
+            is used to manage the "Todos Simple" state. Feature Store state becomes part of the
+            <strong>global state</strong>
+            object.
         </div>
     </div>
 
@@ -50,7 +55,7 @@
                     (create)="todosSimpleStore.create($event)"
                     (update)="todosSimpleStore.update($event)"
                     (delete)="todosSimpleStore.delete($event)"
-                    (close)="todosSimpleStore.clearSelectedTodo()"
+                    (closed)="todosSimpleStore.clearSelectedTodo()"
                 ></app-todo-detail>
             </div>
         </div>

--- a/apps/mini-rx-angular-demo/src/app/modules/todos/components/todos-shell/todos-shell.component.html
+++ b/apps/mini-rx-angular-demo/src/app/modules/todos/components/todos-shell/todos-shell.component.html
@@ -58,7 +58,7 @@
                         (create)="todosState.create($event)"
                         (update)="todosState.update($event)"
                         (delete)="todosState.delete($event)"
-                        (close)="todosState.clearSelectedTodo()"
+                        (closed)="todosState.clearSelectedTodo()"
                     ></app-todo-detail>
                 </div>
             </div>

--- a/apps/signal-store-angular-demo-standalone/src/app/app.component.ts
+++ b/apps/signal-store-angular-demo-standalone/src/app/app.component.ts
@@ -6,7 +6,7 @@ import { UserFacade } from './user/state/user-facade.service';
 @Component({
     standalone: true,
     imports: [RouterModule],
-    selector: 'mini-rx-root',
+    selector: 'app-mini-rx-root',
     templateUrl: './app.component.html',
     styleUrls: ['./app.component.scss'],
 })

--- a/apps/signal-store-angular-demo-standalone/src/app/app.component.ts
+++ b/apps/signal-store-angular-demo-standalone/src/app/app.component.ts
@@ -6,7 +6,7 @@ import { UserFacade } from './user/state/user-facade.service';
 @Component({
     standalone: true,
     imports: [RouterModule],
-    selector: 'app-mini-rx-root',
+    selector: 'app-root',
     templateUrl: './app.component.html',
     styleUrls: ['./app.component.scss'],
 })

--- a/apps/signal-store-angular-demo-standalone/src/app/products/components/product-detail/product-detail.component.ts
+++ b/apps/signal-store-angular-demo-standalone/src/app/products/components/product-detail/product-detail.component.ts
@@ -32,7 +32,7 @@ export class ProductDetailComponent {
     delete = new EventEmitter<Product>();
 
     @Output()
-    close = new EventEmitter<void>();
+    closed = new EventEmitter<void>();
 
     submit(form: NgForm) {
         const newProduct: Product = {

--- a/apps/signal-store-angular-demo-standalone/src/app/products/components/products-shell/products-shell.component.html
+++ b/apps/signal-store-angular-demo-standalone/src/app/products/components/products-shell/products-shell.component.html
@@ -59,7 +59,7 @@
                     (create)="productsFacade.create($event)"
                     (update)="productsFacade.update($event)"
                     (delete)="productsFacade.delete($event)"
-                    (close)="productsFacade.clearCurrentProduct()"
+                    (closed)="productsFacade.clearCurrentProduct()"
                 ></app-product-detail>
             </div>
         </div>

--- a/apps/signal-store-angular-demo-standalone/src/app/products/models/cart-item.ts
+++ b/apps/signal-store-angular-demo-standalone/src/app/products/models/cart-item.ts
@@ -1,6 +1,6 @@
 export class CartItem {
     productId: number | undefined;
-    amount: number = 0;
+    amount = 0;
 
     // UI only
     productName?: string;

--- a/apps/signal-store-angular-demo-standalone/src/app/products/models/product.ts
+++ b/apps/signal-store-angular-demo-standalone/src/app/products/models/product.ts
@@ -1,9 +1,9 @@
 /* Defines the product entity */
 export class Product {
     id: number | undefined;
-    productName: string = '';
-    productCode: string = 'New';
-    description: string = '';
-    starRating: number = 0;
+    productName = '';
+    productCode = 'New';
+    description = '';
+    starRating = 0;
     price: number | undefined;
 }

--- a/apps/signal-store-angular-demo-standalone/src/app/todos-shared/components/todo-detail/todo-detail.component.ts
+++ b/apps/signal-store-angular-demo-standalone/src/app/todos-shared/components/todo-detail/todo-detail.component.ts
@@ -25,7 +25,7 @@ export class TodoDetailComponent {
     delete = new EventEmitter<Todo>();
 
     @Output()
-    close = new EventEmitter<void>();
+    closed = new EventEmitter<void>();
 
     submit() {
         if (this.todo.id) {

--- a/apps/signal-store-angular-demo-standalone/src/app/todos-shared/models/todo.ts
+++ b/apps/signal-store-angular-demo-standalone/src/app/todos-shared/models/todo.ts
@@ -1,7 +1,7 @@
 export class Todo {
     id: number | undefined;
-    title: string = '';
-    isDone: boolean = false;
+    title = '';
+    isDone = false;
     isBusiness?: boolean;
     isPrivate?: boolean;
     tempId?: string;

--- a/apps/signal-store-angular-demo-standalone/src/app/todos-simple/components/todos-simple-shell/todos-simple-shell.component.html
+++ b/apps/signal-store-angular-demo-standalone/src/app/todos-simple/components/todos-simple-shell/todos-simple-shell.component.html
@@ -55,7 +55,7 @@
                     (create)="todosSimpleFacade.create($event)"
                     (update)="todosSimpleFacade.updateTodo($event)"
                     (delete)="todosSimpleFacade.delete($event)"
-                    (close)="todosSimpleFacade.clearSelectedTodo()"
+                    (closed)="todosSimpleFacade.clearSelectedTodo()"
                 ></app-todo-detail>
             </div>
         </div>

--- a/apps/signal-store-angular-demo-standalone/src/app/todos/components/todos-shell/todos-shell.component.html
+++ b/apps/signal-store-angular-demo-standalone/src/app/todos/components/todos-shell/todos-shell.component.html
@@ -56,7 +56,7 @@
                     (create)="todosFacade.create($event)"
                     (update)="todosFacade.updateTodo($event)"
                     (delete)="todosFacade.delete($event)"
-                    (close)="todosFacade.clearSelectedTodo()"
+                    (closed)="todosFacade.clearSelectedTodo()"
                 ></app-todo-detail>
             </div>
         </div>

--- a/apps/signal-store-angular-demo-standalone/src/index.html
+++ b/apps/signal-store-angular-demo-standalone/src/index.html
@@ -8,6 +8,6 @@
         <link rel="icon" type="image/x-icon" href="favicon.ico" />
     </head>
     <body>
-        <mini-rx-root></mini-rx-root>
+        <app-mini-rx-root></app-mini-rx-root>
     </body>
 </html>

--- a/apps/signal-store-angular-demo-standalone/src/index.html
+++ b/apps/signal-store-angular-demo-standalone/src/index.html
@@ -8,6 +8,6 @@
         <link rel="icon" type="image/x-icon" href="favicon.ico" />
     </head>
     <body>
-        <app-mini-rx-root></app-mini-rx-root>
+        <app-root></app-root>
     </body>
 </html>

--- a/libs/common/src/lib/create-register-effect-fn.spec.ts
+++ b/libs/common/src/lib/create-register-effect-fn.spec.ts
@@ -1,4 +1,6 @@
-import { Action, createRegisterEffectFn, createRxEffect } from '@mini-rx/common';
+import { Action } from './models';
+import { createRegisterEffectFn } from './create-register-effect-fn';
+import { createRxEffect } from './create-rx-effect';
 import { Subject } from 'rxjs';
 
 describe('createRegisterEffectFn', () => {

--- a/libs/common/src/lib/create-store.spec.ts
+++ b/libs/common/src/lib/create-store.spec.ts
@@ -1,4 +1,6 @@
-import { Action, createStore, UndoExtension } from '@mini-rx/common';
+import { Action } from './models';
+import { createStore } from './create-store';
+import { UndoExtension } from './extensions/undo/undo-extension';
 
 interface CounterState {
     counter: number;

--- a/libs/common/src/lib/create-update-fn.spec.ts
+++ b/libs/common/src/lib/create-update-fn.spec.ts
@@ -1,10 +1,6 @@
-import {
-    Action,
-    createMiniRxActionType,
-    createUpdateFn,
-    OperationType,
-    StateOrCallback,
-} from '@mini-rx/common';
+import { Action, OperationType, StateOrCallback } from './models';
+import { createMiniRxActionType } from './create-mini-rx-action-type';
+import { createUpdateFn } from './create-update-fn';
 
 describe('createUpdateFn', () => {
     it('should create a setState function using OperationType.SET_STATE', () => {

--- a/libs/common/src/lib/create-update-fn.ts
+++ b/libs/common/src/lib/create-update-fn.ts
@@ -1,4 +1,4 @@
-import { Action, OperationType, StateOrCallback, UpdateStateCallback } from '@mini-rx/common';
+import { Action, OperationType, StateOrCallback, UpdateStateCallback } from './models';
 
 export function createUpdateFn<StateType>(updateStateCallback: UpdateStateCallback<StateType>) {
     return (stateOrCallback: StateOrCallback<StateType>, name?: string): Action => {

--- a/libs/common/src/lib/deep-freeze.spec.ts
+++ b/libs/common/src/lib/deep-freeze.spec.ts
@@ -62,7 +62,9 @@ describe('deepFreeze', () => {
             str: 'immutable',
             num: 42,
             bool: true,
-            fn: function () {},
+            fn: function () {
+                return;
+            },
             nested: {
                 arr: [1, 2, { objProp: 'value' }],
             },

--- a/libs/common/src/lib/deep-freeze.spec.ts
+++ b/libs/common/src/lib/deep-freeze.spec.ts
@@ -62,7 +62,7 @@ describe('deepFreeze', () => {
             str: 'immutable',
             num: 42,
             bool: true,
-            fn: function () {
+            fn: () => {
                 return;
             },
             nested: {

--- a/libs/common/src/lib/generate-feature-key.spec.ts
+++ b/libs/common/src/lib/generate-feature-key.spec.ts
@@ -1,4 +1,4 @@
-import { generateFeatureKey } from '@mini-rx/common';
+import { generateFeatureKey } from './generate-feature-key';
 
 describe('generateFeatureKey', () => {
     it('should generate a feature key', () => {

--- a/libs/mini-rx-store/src/lib/selector.ts
+++ b/libs/mini-rx-store/src/lib/selector.ts
@@ -114,7 +114,7 @@ export function createSelector(...args: any[]): Selector<any, any> {
 
     return memoizeOne((state) => {
         const selectorResults = selectors.map((fn) => fn(state));
-        return memoizedProjector.apply(null, selectorResults);
+        return memoizedProjector(...selectorResults);
     });
 }
 

--- a/libs/signal-store/src/lib/spec/mini-rx-to-observable.spec.ts
+++ b/libs/signal-store/src/lib/spec/mini-rx-to-observable.spec.ts
@@ -28,10 +28,10 @@ describe('toObservable()', () => {
         template: '',
         standalone: true,
     })
-    class Cmp {}
+    class SomeComponent {}
 
     beforeEach(() => {
-        fixture = TestBed.createComponent(Cmp);
+        fixture = TestBed.createComponent(SomeComponent);
         injector = TestBed.inject(EnvironmentInjector);
     });
 
@@ -73,8 +73,8 @@ describe('toObservable()', () => {
 
         const counter$ = toObservable(counter, { injector });
 
-        let currentValue: number = 0;
-        let currentError: any = null;
+        let currentValue = 0;
+        let currentError = null;
 
         const sub = counter$.subscribe({
             next: (value) => (currentValue = value),


### PR DESCRIPTION
Fixed all linting errors that were returned when running `yarn run lint:all`.

```
  yarn run lint:all --skip-nx-cache
yarn run v1.22.22
$ nx run-many --all --target=lint --skip-nx-cache

 NX   --skip-nx-cache disables the connection to Nx Cloud for the current run.

The remote cache will not be read from or written to during this run.


   ✔  nx run mini-rx-store:lint (4s)
   ✔  nx run common:lint (5s)
   ✔  nx run mini-rx-store-ng:lint (6s)
   ✔  nx run signal-store:lint (2s)
   ✔  nx run signal-store-angular-demo-standalone:lint (2s)
   ✔  nx run signal-store-angular-demo-standalone-e2e:lint (798ms)
   ✔  nx run mini-rx-angular-demo-e2e:lint (766ms)
   ✔  nx run mini-rx-angular-demo:lint (2s)

—————————————————————————————————————————————————————————————————————————————————————————————————————————————

 NX   Successfully ran target lint for 8 projects (7s)

✨  Done in 8.67s.
```