### PR TITLE
feat(general): enforce module boundaries with nx

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,30 @@
                         "allow": [],
                         "depConstraints": [
                             {
-                                "sourceTag": "*",
+                                "sourceTag": "scope:signal-store",
+                                "onlyDependOnLibsWithTags": ["scope:common"]
+                            },
+                            {
+                                "sourceTag": "scope:mini-rx-store",
+                                "onlyDependOnLibsWithTags": ["scope:common"]
+                            },
+                            {
+                                "sourceTag": "scope:signal-store-angular-demo-standalone",
+                                "onlyDependOnLibsWithTags": ["scope:signal-store"]
+                            },
+                            {
+                                "sourceTag": "scope:mini-rx-store-demo",
+                                "onlyDependOnLibsWithTags": [
+                                    "scope:mini-rx-store",
+                                    "scope:mini-rx-store-ng"
+                                ]
+                            },
+                            {
+                                "sourceTag": "scope:mini-rx-store-ng",
+                                "onlyDependOnLibsWithTags": ["*"]
+                            },
+                            {
+                                "sourceTag": "scope:mini-rx-angular-demo",
                                 "onlyDependOnLibsWithTags": ["*"]
                             }
                         ]

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,7 +25,7 @@
                                 "onlyDependOnLibsWithTags": ["scope:signal-store"]
                             },
                             {
-                                "sourceTag": "scope:mini-rx-store-demo",
+                                "sourceTag": "scope:mini-rx-angular-demo",
                                 "onlyDependOnLibsWithTags": [
                                     "scope:mini-rx-store",
                                     "scope:mini-rx-store-ng"
@@ -33,11 +33,7 @@
                             },
                             {
                                 "sourceTag": "scope:mini-rx-store-ng",
-                                "onlyDependOnLibsWithTags": ["*"]
-                            },
-                            {
-                                "sourceTag": "scope:mini-rx-angular-demo",
-                                "onlyDependOnLibsWithTags": ["*"]
+                                "onlyDependOnLibsWithTags": ["scope:mini-rx-store"]
                             }
                         ]
                     }

--- a/apps/mini-rx-angular-demo-e2e/project.json
+++ b/apps/mini-rx-angular-demo-e2e/project.json
@@ -3,7 +3,7 @@
     "$schema": "../../node_modules/nx/schemas/project-schema.json",
     "sourceRoot": "apps/mini-rx-angular-demo-e2e/src",
     "projectType": "application",
-    "tags": [],
+    "tags": ["scope:mini-rx-angular-demo-e2e"],
     "implicitDependencies": ["mini-rx-angular-demo"],
     "targets": {
         "e2e": {

--- a/apps/mini-rx-angular-demo/project.json
+++ b/apps/mini-rx-angular-demo/project.json
@@ -4,7 +4,7 @@
     "projectType": "application",
     "sourceRoot": "apps/mini-rx-angular-demo/src",
     "prefix": "app",
-    "tags": [],
+    "tags": ["scope:mini-rx-angular-demo"],
     "targets": {
         "build": {
             "executor": "@angular-devkit/build-angular:browser",

--- a/apps/signal-store-angular-demo-standalone-e2e/project.json
+++ b/apps/signal-store-angular-demo-standalone-e2e/project.json
@@ -3,7 +3,7 @@
     "$schema": "../../node_modules/nx/schemas/project-schema.json",
     "sourceRoot": "apps/signal-store-angular-demo-standalone-e2e/src",
     "projectType": "application",
-    "tags": ["signal-store-angular-demo-standalone-e2e"],
+    "tags": ["scope:signal-store-angular-demo-standalone-e2e"],
     "implicitDependencies": ["signal-store-angular-demo-standalone"],
     "targets": {
         "e2e": {

--- a/apps/signal-store-angular-demo-standalone-e2e/project.json
+++ b/apps/signal-store-angular-demo-standalone-e2e/project.json
@@ -3,7 +3,7 @@
     "$schema": "../../node_modules/nx/schemas/project-schema.json",
     "sourceRoot": "apps/signal-store-angular-demo-standalone-e2e/src",
     "projectType": "application",
-    "tags": [],
+    "tags": ["signal-store-angular-demo-standalone-e2e"],
     "implicitDependencies": ["signal-store-angular-demo-standalone"],
     "targets": {
         "e2e": {

--- a/apps/signal-store-angular-demo-standalone/project.json
+++ b/apps/signal-store-angular-demo-standalone/project.json
@@ -4,7 +4,7 @@
     "projectType": "application",
     "prefix": "app",
     "sourceRoot": "apps/signal-store-angular-demo-standalone/src",
-    "tags": [],
+    "tags": ["scope:signal-store-angular-demo-standalone"],
     "targets": {
         "build": {
             "executor": "@angular-devkit/build-angular:browser",

--- a/libs/common/project.json
+++ b/libs/common/project.json
@@ -3,7 +3,7 @@
     "$schema": "../../node_modules/nx/schemas/project-schema.json",
     "sourceRoot": "libs/common/src",
     "projectType": "library",
-    "tags": [],
+    "tags": ["scope:common"],
     "targets": {
         "build": {
             "executor": "@nx/rollup:rollup",

--- a/libs/mini-rx-store-ng/project.json
+++ b/libs/mini-rx-store-ng/project.json
@@ -4,7 +4,7 @@
     "projectType": "library",
     "sourceRoot": "libs/mini-rx-store-ng/src",
     "prefix": "mini-rx",
-    "tags": [],
+    "tags": ["scope:mini-rx-store-ng"],
     "targets": {
         "build": {
             "executor": "@nx/angular:package",

--- a/libs/mini-rx-store/project.json
+++ b/libs/mini-rx-store/project.json
@@ -3,7 +3,7 @@
     "$schema": "../../node_modules/nx/schemas/project-schema.json",
     "sourceRoot": "libs/mini-rx-store/src",
     "projectType": "library",
-    "tags": [],
+    "tags": ["scope:mini-rx-store"],
     "targets": {
         "build": {
             "executor": "@nx/rollup:rollup",

--- a/libs/signal-store/project.json
+++ b/libs/signal-store/project.json
@@ -4,7 +4,7 @@
     "sourceRoot": "libs/signal-store/src",
     "prefix": "mini-rx",
     "projectType": "library",
-    "tags": [],
+    "tags": ["scope:signal-store"],
     "targets": {
         "build": {
             "executor": "@nx/angular:package",


### PR DESCRIPTION
Enforce module boundaries with nx to prevent unwanted dependencies from one project to the other.

Documentation: https://nx.dev/features/enforce-module-boundaries

Rules set:
- `signal-store` can only import from `common`
- `mini-rx-store` can only import from `common`
- `signal-store-angular-demo-standalone` can only import from `signal-store`
- `mini-rx-angular-demo` can only import from `mini-rx-store` and `mini-rx-store-ng`
- `mini-rx-store-ng` can only import from `mini-rx-store`
- `common` can not import from another project