### PR TITLE
fix(mini-rx-store-ng): fix nx module boundaries

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,7 +33,13 @@
                             },
                             {
                                 "sourceTag": "scope:mini-rx-store-ng",
-                                "onlyDependOnLibsWithTags": ["scope:mini-rx-store"]
+                                "onlyDependOnLibsWithTags": ["scope:mini-rx-store", "scope:common"],
+                                "allowedExternalImports": [
+                                    "@angular/*",
+                                    "rxjs",
+                                    "rxjs/*",
+                                    "jest-preset-angular/*"
+                                ]
                             }
                         ]
                     }


### PR DESCRIPTION
Adjusted nx module boundaries because the linting command `npm run lint:all` returned errors for `mini-rx-store-ng`